### PR TITLE
sysctl fixes

### DIFF
--- a/attributes/sysctl.rb
+++ b/attributes/sysctl.rb
@@ -163,7 +163,7 @@ end
 # * **128** - reboot/poweroff
 # * **256** - nicing of all RT tasks
 default[:sysctl][:params][:kernel][:sysrq] =
-    node[:security][:kernel][:enable_sysrq] || 0
+    node[:security][:kernel][:enable_sysrq] ? node[:security][:kernel][:secure_sysrq] || 0
 
 
 # Prevent core dumps with SUID. These are usually only needed by developers and


### PR DESCRIPTION
- bugfix: determine ipv4 forwarding from user forwarding configuration
- bugfix: determine ipv6 forwarding from user forwarding + ipv6 configuration
  fixes #9 
- bugfix: correctly enable sysrqs if desired
  fixes #6
