### PR TITLE
remove ntp

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ It will not:
 * Cookbooks:
   * Opscode sysctl `https://github.com/onehealth-cookbooks/sysctl`
   * Opscode apt `https://github.com/opscode-cookbooks/apt.git`
-  * Opscode ntp `https://github.com/gmiranda23/ntp.git`
   * Opscode yum `https://github.com/opscode-cookbooks/yum.git`
 
 Optional: you can use berkshelf to install dependencies.

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -30,7 +30,6 @@
         cd cookbooks
         git clone https://github.com/onehealth-cookbooks/sysctl
         git clone https://github.com/opscode-cookbooks/apt.git
-        git clone https://github.com/gmiranda23/ntp.git
         git clone https://github.com/opscode-cookbooks/yum.git
         cd ..
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,7 +7,6 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          "1.0.1"
 
 depends 'sysctl', '0.3.4'
-depends 'ntp'
 depends 'apt'
 depends 'yum'
 

--- a/recipes/packages.rb
+++ b/recipes/packages.rb
@@ -17,9 +17,6 @@
 # limitations under the License.
 #
 
-# tp should be on every machine to ensure the time is synced
-include_recipe "ntp"
-
 # do package config for ubuntu
 case node[:platform_family]
 when "debian"


### PR DESCRIPTION
while i personally approve the idea that NTP must be on every machine, i would prefer to have it done separately and with hardening options. it's currently a separate module at opscode and i think we should align with this strategy to not meld it too deeply into os-hardening. opinions?

Solves #19 

Signed-off-by: Dominik Richter dominik.richter@gmail.com
