### PR TITLE
improvement: clarify SUID/SGID options in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,9 +74,9 @@ Optional: you can use berkshelf to install dependencies.
 * `['security']['suid_sgid']['whitelist'] = []`
   a list of paths which should not have their SUID/SGID bits altered
 * `['security']['suid_sgid']['remove_from_unkown'] = false`
-  true if you want to remove SUID/SGID bits from any file, that is not explicitly configured in a whitelist or blacklist
+  true if you want to remove SUID/SGID bits from any file, that is not explicitly configured in a `blacklist`. This will make every Chef run search through the mounted filesystems looking for SUID/SGID bits that are not configured in the default and user blacklist. If it finds an SUID/SGID bit, it will be removed, unless this file is in your `whitelist`.
 * `['security']['suid_sgid']['dry_run_on_unkown'] = false`
-  like `remove_from_unknown`, only that changes aren't applied but only printed
+  like `remove_from_unknown` above, only that SUID/SGID bits aren't removed. It will still search the filesystems to look for SUID/SGID bits but it will only print them in your log. This option is only ever recommended, when you first configure `remove_from_unkown` for SUID/SGID bits, so that you can see the files that are being changed and make adjustments to your `whitelist` and `blacklist`.
 * `['security']['packages']['clean']  = true` 
   removes packages with known issues. See section packages.
 


### PR DESCRIPTION
make sure that remove_from_unkown and dry_run_on_unkown are better understandable in the readme.

Signed-off-by: Dominik Richter dominik.richter@gmail.com
