### PR TITLE
Sysctl update to 0.6.0

### DIFF
--- a/libraries/cookbook_version.rb
+++ b/libraries/cookbook_version.rb
@@ -1,0 +1,34 @@
+# encoding: utf-8
+#
+# Cookbook Name:: os-hardening
+# Library:: cookbook_version
+#
+# Copyright 2014, Dominik Richter
+# Copyright 2014, Deutsche Telekom AG
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+class Chef
+  class Recipe
+    def cookbook_version(cookbook_name, version_contraint)
+      cb = run_context.cookbook_collection[cookbook_name]
+      if cb.nil?
+        fail "Can't find cookbook #{cookbook_name}! Can't determine its version."
+      end
+
+      v = cb.metadata.version
+      Chef::VersionConstraint::Platform.new(version_contraint).include?(v)
+    end
+  end
+end

--- a/metadata.rb
+++ b/metadata.rb
@@ -29,7 +29,7 @@ supports 'centos', '>= 6.4'
 supports 'redhat', '>= 6.4'
 supports 'oracle', '>= 6.4'
 
-depends 'sysctl', '>= 0.6.0'
+depends 'sysctl', '>= 0.3.0'
 depends 'apt'
 depends 'yum'
 

--- a/recipes/sysctl.rb
+++ b/recipes/sysctl.rb
@@ -20,7 +20,14 @@
 #
 
 # include sysctl recipe and set /etc/sysctl.d/99-chef-attributes.conf
-include_recipe 'sysctl::apply'
+if cookbook_version('sysctl', '< 0.6.0')
+  log 'DEPRECATION: You use an older version of chef-sysctl. chef-os-hardening will not support this version in future releases.' do
+    level :warn
+  end
+  include_recipe 'sysctl'
+else
+  include_recipe 'sysctl::apply'
+end
 
 cpu_vendor = node['cpu']['0']['vendor_id']
   .sub(/^.*GenuineIntel.*$/, 'intel')


### PR DESCRIPTION
Update sysctl to current release 0.6.0.
This requires an api change: including recipe "sysctl" => "sysctl:apply". This makes it incompatible with releases <0.6.0.

Thanks to @rmoriz for pointing to the outdated version in #44!

One more thing to clear: I don't know whether we should make this into a conditional, i.e. support sysctl <0.6.0 and >= 0.6.0. It's certainly possible to get the deployed cookbook version and run internals for version comparison (since chef provides methods for both).

Let's clear this before merging.
