### PR TITLE
Drop procps service

### DIFF
--- a/recipes/sysctl.rb
+++ b/recipes/sysctl.rb
@@ -85,5 +85,6 @@ when 'debian'
     provider service_provider
     supports restart: false, reload: false
     action [:enable, :start]
+    only_if { cookbook_version('sysctl', '< 0.6.0') }
   end
 end


### PR DESCRIPTION
since we now have support for sysctl::apply, we can get rid of the kludge of starting service props on every chef run.

btw: any reason why we do not just bump our dependency on the sysctl cookbook to ~> 0.6.0 and get rid of the special casing all together?
