### PR TITLE
fix chefspec depreciation warning about `should`

### DIFF
--- a/spec/recipes/default_spec.rb
+++ b/spec/recipes/default_spec.rb
@@ -32,14 +32,14 @@ describe 'os-hardening::default' do
 
   # check that the recipres are executed
   it 'default should include os-hardening recipes by default' do
-    chef_run.should include_recipe 'os-hardening::packages'
-    chef_run.should include_recipe 'os-hardening::limits'
-    chef_run.should include_recipe 'os-hardening::login_defs'
-    chef_run.should include_recipe 'os-hardening::minimize_access'
-    chef_run.should include_recipe 'os-hardening::pam'
-    chef_run.should include_recipe 'os-hardening::profile'
-    chef_run.should include_recipe 'os-hardening::securetty'
-    chef_run.should include_recipe 'os-hardening::sysctl'
+    expect(chef_run).to include_recipe 'os-hardening::packages'
+    expect(chef_run).to include_recipe 'os-hardening::limits'
+    expect(chef_run).to include_recipe 'os-hardening::login_defs'
+    expect(chef_run).to include_recipe 'os-hardening::minimize_access'
+    expect(chef_run).to include_recipe 'os-hardening::pam'
+    expect(chef_run).to include_recipe 'os-hardening::profile'
+    expect(chef_run).to include_recipe 'os-hardening::securetty'
+    expect(chef_run).to include_recipe 'os-hardening::sysctl'
   end
 
 end


### PR DESCRIPTION
Trivial fix for the following warning:

```

Deprecation Warnings:

Using `should` from rspec-expectations' old `:should` syntax without explicitly
enabling the syntax is deprecated. Use the new `:expect` syntax or explicitly enable `:should` instead.
Called from […]/chef-os-hardening/spec/recipes/default_spec.rb:35:in `block (2 levels) in <top (required)>'.


If you need more of the backtrace for any of these deprecations to
identify where to make the necessary changes, you can configure
`config.raise_errors_for_deprecations!`, and it will turn the
deprecation warnings into errors, giving you the full backtrace.
```
