### PR TITLE
Don't step into other cookbook's namespaces (ie `packages` cookbook)

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -21,24 +21,24 @@
 # Define the packages based on operating system
 case platform_family
 when 'rhel', 'fedora'
-  default['packages']['pam_ccreds'] = 'pam_ccreds'
-  default['packages']['pam_passwdqc'] = 'pam_passwdqc'
-  default['packages']['pam_cracklib'] = 'pam_cracklib'
+  default['hardening-io']['packages']['pam_ccreds'] = 'pam_ccreds'
+  default['hardening-io']['packages']['pam_passwdqc'] = 'pam_passwdqc'
+  default['hardening-io']['packages']['pam_cracklib'] = 'pam_cracklib'
 
 when 'debian'
-  default['packages']['pam_ccreds'] = 'libpam-ccreds'
-  default['packages']['pam_passwdqc'] = 'libpam-passwdqc'
-  default['packages']['pam_cracklib'] = 'libpam-cracklib'
+  default['hardening-io']['packages']['pam_ccreds'] = 'libpam-ccreds'
+  default['hardening-io']['packages']['pam_passwdqc'] = 'libpam-passwdqc'
+  default['hardening-io']['packages']['pam_cracklib'] = 'libpam-cracklib'
 
 when 'arch'
-  default['packages']['pam_ccreds'] = 'pam_ccreds'
-  default['packages']['pam_passwdqc'] = 'pam_passwdqc'
-  default['packages']['pam_cracklib'] = 'pam_cracklib'
+  default['hardening-io']['packages']['pam_ccreds'] = 'pam_ccreds'
+  default['hardening-io']['packages']['pam_passwdqc'] = 'pam_passwdqc'
+  default['hardening-io']['packages']['pam_cracklib'] = 'pam_cracklib'
 
 else
-  default['packages']['pam_ccreds'] = 'pam_ccreds'
-  default['packages']['pam_passwdqc'] = 'pam_passwdqc'
-  default['packages']['pam_cracklib'] = 'pam_cracklib'
+  default['hardening-io']['packages']['pam_ccreds'] = 'pam_ccreds'
+  default['hardening-io']['packages']['pam_passwdqc'] = 'pam_passwdqc'
+  default['hardening-io']['packages']['pam_cracklib'] = 'pam_cracklib'
 end
 
 # rhel, centos autoconf configuration

--- a/recipes/pam.rb
+++ b/recipes/pam.rb
@@ -26,7 +26,7 @@ end
 
 # remove ccreds if not necessary
 package 'pam-ccreds' do
-  package_name node['packages']['pam_ccreds']
+  package_name node['hardening-io']['packages']['pam_ccreds']
   action :remove
 end
 
@@ -42,13 +42,13 @@ when 'debian'
 
     # remove pam_cracklib, because it does not play nice wiht passwdqc
     package 'pam-cracklib' do
-      package_name node['packages']['pam_cracklib']
+      package_name node['hardening-io']['packages']['pam_cracklib']
       action :remove
     end
 
     # get the package for strong password checking
     package 'pam-passwdqc' do
-      package_name node['packages']['pam_passwdqc']
+      package_name node['hardening-io']['packages']['pam_passwdqc']
     end
 
     # configure passwdqc via central module:
@@ -70,7 +70,7 @@ when 'debian'
     # make sure the package is not on the system,
     # if this feature is not wanted
     package 'pam-passwdqc' do
-      package_name node['packages']['pam_passwdqc']
+      package_name node['hardening-io']['packages']['pam_passwdqc']
       action :remove
     end
   end
@@ -106,13 +106,13 @@ when 'rhel', 'fedora'
 
     # remove pam_cracklib, because it does not play nice wiht passwdqc
     package 'pam-cracklib' do
-      package_name node['packages']['pam_cracklib']
+      package_name node['hardening-io']['packages']['pam_cracklib']
       action :remove
     end
 
     # get the package for strong password checking
     package 'pam-passwdqc' do
-      package_name node['packages']['pam_passwdqc']
+      package_name node['hardening-io']['packages']['pam_passwdqc']
     end
 
   # deactivate passwdqc
@@ -121,7 +121,7 @@ when 'rhel', 'fedora'
     # make sure the package is not on the system,
     # if this feature is not wanted
     package 'pam-passwdqc' do
-      package_name node['packages']['pam_passwdqc']
+      package_name node['hardening-io']['packages']['pam_passwdqc']
       action :remove
     end
   end


### PR DESCRIPTION
There is a cookbook called `packages`, which should rightfully have that namespace in the node, but this cookbook tried to use it :)

https://github.com/mattray/packages-cookbook/blob/master/attributes/default.rb

https://github.com/hardening-io/chef-os-hardening/blob/master/attributes/default.rb

Is there another namespace we could use, and is it possible to stop using this pattern and stick with one high-level namespace for this cookbook?