### PR TITLE
Initial support for CentOS/RHEL 5

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -13,6 +13,10 @@ platforms:
   driver_config:
     box: ubuntu/trusty64
     box_url: https://atlas.hashicorp.com/ubuntu/boxes/trusty64/versions/20150609.0.10/providers/virtualbox.box
+- name: centos-5.11
+  driver_config:
+    box: opscode-centos-5.11
+    box_url: https://opscode-vm.s3.amazonaws.com/vagrant/opscode_centos-5.11_provisionerless.box
 - name: centos-6.4
   driver_config:
     box: opscode-centos-6.4

--- a/libraries/suid_sgid.rb
+++ b/libraries/suid_sgid.rb
@@ -36,7 +36,8 @@ class Chef
       def self.find_all_suid_sgid_files(start_at = '/')
         # "find / -xdev \( -perm -4000 -o -perm -2000 \) -type f -print 2>/dev/null"
         # don't limit to one filesystem, go nuts recursively: (ie without -xdev)
-        findcmd = "find #{start_at} \\( -perm -4000 -o -perm -2000 \\) -type f ! -path '/proc/*' -print 2>/dev/null"
+        findcmd = "find #{start_at} -path /proc -prune -o \\( -perm -4000 -o -perm -2000 \\) -type f -print 2>/dev/null"
+        Chef::Log.info "suid_sgid: findcmd #{findcmd}"
         find = Mixlib::ShellOut.new(findcmd)
         find.run_command
         find.error!

--- a/metadata.rb
+++ b/metadata.rb
@@ -25,8 +25,8 @@ version          "1.3.1"
 
 supports 'ubuntu', '>= 12.04'
 supports 'debian', '>= 6.0'
-supports 'centos', '>= 6.4'
-supports 'redhat', '>= 6.4'
+supports 'centos', '>= 5.0'
+supports 'redhat', '>= 5.0'
 supports 'oracle', '>= 6.4'
 
 depends 'sysctl', '>= 0.3.0'

--- a/templates/default/login.defs.erb
+++ b/templates/default/login.defs.erb
@@ -111,16 +111,20 @@ PASS_WARN_AGE	7
 # Min/max values for automatic uid selection in useradd
 UID_MIN			 <%= @uid_min.to_s %>
 UID_MAX			60000
+<% unless node['platform_family'] == 'rhel' and node['platform_version'].to_f < 6.0 %>
 # System accounts
 SYS_UID_MIN		  <%= @sys_uid_min.to_s %>
 SYS_UID_MAX		  <%= @sys_uid_max.to_s %>
+<% end %>
 
 # Min/max values for automatic gid selection in groupadd
 GID_MIN			 <%= @gid_min.to_s %>
 GID_MAX			60000
+<% unless node['platform_family'] == 'rhel' and node['platform_version'].to_f < 6.0 %>
 # System accounts
 SYS_GID_MIN		  <%= @sys_gid_min.to_s %>
 SYS_GID_MAX		  <%= @sys_gid_max.to_s %>
+<% end %>
 
 # Max number of login retries if password is bad. This will most likely be overriden by PAM, since the default pam_unix module has it's own built in of 3 retries. However, this is a safe fallback in case you are using an authentication module that does not enforce PAM_MAXTRIES.
 LOGIN_RETRIES		<%= @login_retries.to_s %>


### PR DESCRIPTION
* Find was descending into /proc, causing file not found errors and a non-zero return value, causing converge to fail.  This is fixed by using the -prune action to skip recursion into /proc entirely.
* A kitchen configuration for CentOS 5 is added.