### PR TITLE
Pam options and fixes

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -61,6 +61,7 @@ default['auth']['timeout']                            = 60
 default['auth']['allow_homeless']                     = false
 default['auth']['pam']['passwdqc']['enable']            = true
 default['auth']['pam']['passwdqc']['options']           = 'min=disabled,disabled,16,12,8'
+default['auth']['pam']['cracklib']['options']           = 'try_first_pass retry=3 type='
 default['auth']['root_ttys']                          = %w(console tty1 tty2 tty3 tty4 tty5 tty6)
 default['auth']['uid_min']                             = 1000
 default['auth']['gid_min']                             = 1000

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -24,6 +24,15 @@ when 'rhel', 'fedora'
   default['packages']['pam_ccreds'] = 'pam_ccreds'
   default['packages']['pam_passwdqc'] = 'pam_passwdqc'
   default['packages']['pam_cracklib'] = 'pam_cracklib'
+  default['packages']['pam_pwquality'] = 'libpwquality'
+
+  if platform_version.to_f < 7
+    default['auth']['pam']['passwdqc']['enable']  = true
+    default['auth']['pam']['pwquality']['enable']  = false
+  else
+    default['auth']['pam']['passwdqc']['enable']  = false
+    default['auth']['pam']['pwquality']['enable']  = true
+  end
 
 when 'debian'
   default['packages']['pam_ccreds'] = 'libpam-ccreds'
@@ -59,9 +68,9 @@ default['auth']['retries']                            = 5
 default['auth']['lockout_time']                       = 600 # 10min
 default['auth']['timeout']                            = 60
 default['auth']['allow_homeless']                     = false
-default['auth']['pam']['passwdqc']['enable']            = true
 default['auth']['pam']['passwdqc']['options']           = 'min=disabled,disabled,16,12,8'
 default['auth']['pam']['cracklib']['options']           = 'try_first_pass retry=3 type='
+default['auth']['pam']['pwquality']['options']          = 'try_first_pass retry=3 type='
 default['auth']['root_ttys']                          = %w(console tty1 tty2 tty3 tty4 tty5 tty6)
 default['auth']['uid_min']                             = 1000
 default['auth']['gid_min']                             = 1000

--- a/templates/default/rhel_system_auth.erb
+++ b/templates/default/rhel_system_auth.erb
@@ -22,6 +22,8 @@ account     required      pam_permit.so
 
 <% if node['auth']['pam']['passwdqc']['enable'] %>
 password    requisite     pam_passwdqc.so <%= node['auth']['pam']['passwdqc']['options'] %>
+<% elsif node['auth']['pam']['pwquality']['enable'] %>
+password    requisite     pam_pwquality.so <%= node['auth']['pam']['pwquality']['options'] %>
 <% else %>
 password    requisite     pam_cracklib.so <%= node['auth']['pam']['cracklib']['options'] %>
 <% end %>

--- a/templates/default/rhel_system_auth.erb
+++ b/templates/default/rhel_system_auth.erb
@@ -23,7 +23,7 @@ account     required      pam_permit.so
 <% if node['auth']['pam']['passwdqc']['enable'] %>
 password    requisite     pam_passwdqc.so <%= node['auth']['pam']['passwdqc']['options'] %>
 <% else %>
-password    requisite     pam_cracklib.so try_first_pass retry=3 type=
+password    requisite     pam_cracklib.so <%= node['auth']['pam']['cracklib']['options'] %>
 <% end %>
 
 # NSA 2.3.3.5 Upgrade Password Hashing Algorithm to SHA-512


### PR DESCRIPTION
This adds adds an attribute for setting pam_cracklib options and fixes #102 related problems.

- Fixed templates not being applied if pam_passwdqc is enabled.
- Install correct package for pam_pwquality in centos 7.
- Add a flag to turn on/off pam_pwquality in rhel7 and set defaults appropriately based on platform_version
- Add an attribute to set options to pam_pwquality.
- Fall back to pam_cracklib on all patforms if neither pam_pwquality nor pam_passwdqc are enabled.
- Don't attempt to install pam_cracklib (It comes with the pam package on rhel 5, 6, & 7)

@chris-rock Please let me know if  you have any feedback about this or any of my other PRs in this repo. :)