### PR TITLE
Update rhel_system_auth.erb

### DIFF
--- a/templates/default/rhel_system_auth.erb
+++ b/templates/default/rhel_system_auth.erb
@@ -21,11 +21,11 @@ account     sufficient    pam_succeed_if.so uid < 500 quiet
 account     required      pam_permit.so
 
 <% if node['os-hardening']['auth']['pam']['passwdqc']['enable'] %>
-password    requisite     pam_passwdqc.so <%= node['auth']['pam']['passwdqc']['options'] %>
+password    requisite     pam_passwdqc.so <%= node['os-hardening']['auth']['pam']['passwdqc']['options'] %>
 <% elsif node['os-hardening']['auth']['pam']['pwquality']['enable'] %>
-password    requisite     pam_pwquality.so <%= node['auth']['pam']['pwquality']['options'] %>
+password    requisite     pam_pwquality.so <%= node['os-hardening']['auth']['pam']['pwquality']['options'] %>
 <% else %>
-password    requisite     pam_cracklib.so <%= node['auth']['pam']['cracklib']['options'] %>
+password    requisite     pam_cracklib.so <%= node['os-hardening']['auth']['pam']['cracklib']['options'] %>
 <% end %>
 
 # NSA 2.3.3.5 Upgrade Password Hashing Algorithm to SHA-512


### PR DESCRIPTION
Adding os-hardening root namespace to node reference for  /etc/pam.d/system-auth-ac
Was testing your new Beta as previous versions break with the latest Chef client included in AWS Opsworks. Was getting an "undefined method `[]' for nil:NilClass" error on line 26 of rhel_system_auth.erb
This change has worked on our systems, looks like just an oversight.