### PR TITLE
Remove dependenies to apt and yum cookbooks.

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,7 +1,7 @@
 ---
 driver:
   name: dokken
-  chef_version: 12.5.1
+  chef_version: 12.14.89
   privileged: true # because Docker and SystemD/Upstart
 
 transport:

--- a/README.md
+++ b/README.md
@@ -29,11 +29,9 @@ It will not:
 
 ## Requirements
 
-* Chef
+* Chef >= 12.14.89
 * Cookbooks:
   * Sander van Zoest sysctl `https://github.com/svanzoest-cookbooks/sysctl`
-  * Chef apt `https://github.com/chef-cookbooks/apt`
-  * Chef yum `https://github.com/chef-cookbooks/yum`
 
 **Note for `sysctl` usage:**
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -30,8 +30,6 @@ supports 'redhat', '>= 5.0'
 supports 'oracle', '>= 6.4'
 
 depends 'sysctl', '<= 0.7.5'
-depends 'apt', '~> 3.0.0'
-depends 'yum'
 
 recipe 'os-hardening::default', 'harden the operating system (all recipes)'
 recipe 'os-hardening::limits', 'prevent core dumps'

--- a/recipes/apt.rb
+++ b/recipes/apt.rb
@@ -18,8 +18,6 @@
 # limitations under the License.
 #
 
-include_recipe 'apt'
-
 # apt-get and aptitude check package signatures by default.
 # TODO: could check apt.conf to make sure this hasn't been disabled.
 

--- a/recipes/yum.rb
+++ b/recipes/yum.rb
@@ -18,8 +18,6 @@
 # limitations under the License.
 #
 
-include_recipe 'yum'
-
 # NSA chapter: NSA 2.1.2.3.3
 # verify package signatures
 # search /etc/yum.conf gpgcheck=1


### PR DESCRIPTION
The following resources are now completely provided by chef:
 - yum_repository
 - yum_package
 - apt_repository
 - apt_package

Currently you get warnings:
```
WARN: Chef::Provider::AptRepository already exists!  Cannot create deprecation class for LWRP provider apt_repository from cookbook apt
WARN: AptRepository already exists!  Deprecation class overwrites Custom resource apt_repository from cookbook apt
WARN: Chef::Provider::YumRepository already exists!  Cannot create deprecation class for LWRP provider yum_repository from cookbook yum
WARN: YumRepository already exists!  Deprecation class overwrites Custom resource yum_repository from cookbook yum
```

Starting from the version v12.14.89 the behavior of yum_repository
seems to be the same like in the cookbook before. So I used this version
as the requirement.