### PR TITLE
Revert "Remove dependenies to apt and yum cookbooks."

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,7 +1,7 @@
 ---
 driver:
   name: dokken
-  chef_version: 12.14.89
+  chef_version: 12.5.1
   privileged: true # because Docker and SystemD/Upstart
 
 transport:

--- a/README.md
+++ b/README.md
@@ -29,9 +29,11 @@ It will not:
 
 ## Requirements
 
-* Chef >= 12.14.89
+* Chef
 * Cookbooks:
   * Sander van Zoest sysctl `https://github.com/svanzoest-cookbooks/sysctl`
+  * Chef apt `https://github.com/chef-cookbooks/apt`
+  * Chef yum `https://github.com/chef-cookbooks/yum`
 
 **Note for `sysctl` usage:**
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -30,6 +30,8 @@ supports 'redhat', '>= 5.0'
 supports 'oracle', '>= 6.4'
 
 depends 'sysctl', '<= 0.7.5'
+depends 'apt', '~> 3.0.0'
+depends 'yum'
 
 recipe 'os-hardening::default', 'harden the operating system (all recipes)'
 recipe 'os-hardening::limits', 'prevent core dumps'

--- a/recipes/apt.rb
+++ b/recipes/apt.rb
@@ -18,6 +18,8 @@
 # limitations under the License.
 #
 
+include_recipe 'apt'
+
 # apt-get and aptitude check package signatures by default.
 # TODO: could check apt.conf to make sure this hasn't been disabled.
 

--- a/recipes/yum.rb
+++ b/recipes/yum.rb
@@ -18,6 +18,8 @@
 # limitations under the License.
 #
 
+include_recipe 'yum'
+
 # NSA chapter: NSA 2.1.2.3.3
 # verify package signatures
 # search /etc/yum.conf gpgcheck=1


### PR DESCRIPTION
This reverts commit 6e37167db1faa7aca03a78e9c7f8e2d6f79ee55d.

We should use compat_resource if we want compatibility with older chef
versions (<12.14)

Currently I'm running into the following issue https://github.com/chef-cookbooks/compat_resource/issues/122

So I revert the yum/apt dependency removal till it works with
compat_resource