### PR TITLE
Add attribute to control login.defs PASS_WARN_AGE

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -67,4 +67,4 @@ suites:
   - recipe[os-hardening::default]
   verifier:
     inspec_tests:
-    - https://github.com/dev-sec/tests-os-hardening
+    - https://github.com/dev-sec/linux-baseline

--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ We deprecated `sysctl` version before `0.6.0`. Future versions of this cookbook 
   maximum password age
 * `['os-hardening']['auth']['pw_min_age'] = 7`
   minimum password age (before allowing any other password change)
+* `['os-hardening']['auth']['pw_warn_age'] = 7`
+  number of days before maximum password age occurs to warn of impending
+  change
 * `['os-hardening']['auth']['retries'] = 5`
   the maximum number of authentication attempts, before the account is locked for some time
 * `['os-hardening']['auth']['lockout_time'] = 600`

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -63,6 +63,7 @@ default['os-hardening']['env']['umask']                               = '027'
 default['os-hardening']['env']['root_path']                           = '/'
 default['os-hardening']['auth']['pw_max_age']                         = 60
 default['os-hardening']['auth']['pw_min_age']                         = 7 # discourage password cycling
+default['os-hardening']['auth']['pw_warn_age']                        = 7
 default['os-hardening']['auth']['retries']                            = 5
 default['os-hardening']['auth']['lockout_time']                       = 600 # 10min
 default['os-hardening']['auth']['timeout']                            = 60

--- a/recipes/login_defs.rb
+++ b/recipes/login_defs.rb
@@ -28,6 +28,7 @@ template '/etc/login.defs' do
     umask: node['os-hardening']['env']['umask'],
     password_max_age: node['os-hardening']['auth']['pw_max_age'],
     password_min_age: node['os-hardening']['auth']['pw_min_age'],
+    password_warn_age: node['os-hardening']['auth']['pw_warn_age'],
     login_retries: node['os-hardening']['auth']['retries'],
     login_timeout: node['os-hardening']['auth']['timeout'],
     chfn_restrict: '', # "rwh"

--- a/spec/recipes/login_defs_spec.rb
+++ b/spec/recipes/login_defs_spec.rb
@@ -36,6 +36,7 @@ describe 'os-hardening::login_defs' do
         umask: '027',
         password_max_age: 60,
         password_min_age: 7,
+        password_warn_age: 7,
         login_retries: 5,
         login_timeout: 60,
         chfn_restrict: '',
@@ -52,6 +53,7 @@ describe 'os-hardening::login_defs' do
 
   it 'uses uid_min and gid_min in /etc/login.defs' do
     expect(chef_run).to render_file('/etc/login.defs').
+      with_content(/^PASS_WARN_AGE\s+7$/).
       with_content(/^UID_MIN\s+5000$/).
       with_content(/^GID_MIN\s+5000$/)
   end

--- a/templates/default/login.defs.erb
+++ b/templates/default/login.defs.erb
@@ -106,7 +106,7 @@ PASS_MAX_DAYS <%= @password_max_age.to_s %>
 PASS_MIN_DAYS <%= @password_min_age.to_s %>
 
 # Number of days warning given before a password expires.
-PASS_WARN_AGE	7
+PASS_WARN_AGE	<%= @password_warn_age.to_s %>
 
 # Min/max values for automatic uid selection in useradd
 UID_MIN			 <%= @uid_min.to_s %>


### PR DESCRIPTION
Adds `node['os-hardening']['auth']['pass_warn_age']` with a default of `7`, and passes it to the `/etc/login.defs` template.