### PR TITLE
Added platform check - debian and rhel

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -19,12 +19,17 @@
 # limitations under the License.
 #
 
-include_recipe('os-hardening::packages')
-include_recipe('os-hardening::limits')
-include_recipe('os-hardening::login_defs')
-include_recipe('os-hardening::minimize_access')
-include_recipe('os-hardening::pam')
-include_recipe('os-hardening::profile')
-include_recipe('os-hardening::securetty')
-include_recipe('os-hardening::suid_sgid') if node['os-hardening']['security']['suid_sgid']['enforce']
-include_recipe('os-hardening::sysctl')
+case node['platform_family']
+when 'debian', 'rhel'
+
+  include_recipe('os-hardening::packages')
+  include_recipe('os-hardening::limits')
+  include_recipe('os-hardening::login_defs')
+  include_recipe('os-hardening::minimize_access')
+  include_recipe('os-hardening::pam')
+  include_recipe('os-hardening::profile')
+  include_recipe('os-hardening::securetty')
+  include_recipe('os-hardening::suid_sgid') if node['os-hardening']['security']['suid_sgid']['enforce']
+  include_recipe('os-hardening::sysctl')
+
+end


### PR DESCRIPTION
Wrapped default in platform family case for debian and rhel. This allows this hardening cookbook to be added to a remediation role that can be used to address multiple platforms.