### PR TITLE
Cleanup of sysctl dependency

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -29,7 +29,7 @@ supports 'centos', '>= 5.0'
 supports 'redhat', '>= 5.0'
 supports 'oracle', '>= 6.4'
 
-depends 'sysctl', '<= 0.7.5'
+depends 'sysctl', '>= 0.6.0'
 depends 'compat_resource', '>= 12.16.3'
 
 recipe 'os-hardening::default', 'harden the operating system (all recipes)'

--- a/recipes/sysctl.rb
+++ b/recipes/sysctl.rb
@@ -20,15 +20,7 @@
 #
 
 # include sysctl recipe and set /etc/sysctl.d/99-chef-attributes.conf
-# TODO: This is deprecated. Remove after sysctl >= 0.6.0
-if cookbook_version('sysctl', '< 0.6.0')
-  log 'DEPRECATION: You use an older version of chef-sysctl. chef-os-hardening will not support this version in future releases.' do
-    level :warn
-  end
-  include_recipe 'sysctl'
-else
-  include_recipe 'sysctl::apply'
-end
+include_recipe 'sysctl::apply'
 
 # try to determine the real cpu vendor
 begin
@@ -86,21 +78,6 @@ when 'debian'
     execute 'update-initramfs' do
       command 'update-initramfs -u'
       action :run
-    end
-  end
-end
-
-# Conditional handling of procps reload
-# TODO: This is deprecated. Remove after sysctl >= 0.6.0
-# ignore FC023: @see https://github.com/acrmp/foodcritic/issues/151
-if cookbook_version('sysctl', '< 0.6.0') # ~FC023
-  case node['platform_family']
-  when 'debian'
-    service_provider = node['platform'] == 'ubuntu' ? Chef::Provider::Service::Upstart : nil
-    service 'procps' do
-      provider service_provider
-      supports restart: false, reload: false
-      action [:enable, :start]
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,6 +24,10 @@ Coveralls.wear!
 at_exit { ChefSpec::Coverage.report! }
 
 RSpec.configure do |config|
+  # OS and version for mocking of ohai data, needed by chefspec
+  config.platform = 'ubuntu'
+  config.version = '16.04'
+
   config.before(:each) do
     # we have to stub this, as its executed by the sysctl cookbook
     # dependency as native ruby code

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,3 +22,13 @@ require 'coveralls'
 # coverage report
 Coveralls.wear!
 at_exit { ChefSpec::Coverage.report! }
+
+RSpec.configure do |config|
+  config.before(:each) do
+    # we have to stub this, as its executed by the sysctl cookbook
+    # dependency as native ruby code
+    # see http://stackoverflow.com/questions/24270887/stub-file-open-in-chefspec
+    allow(::File).to receive(:exist?).and_call_original
+    allow(::File).to receive(:exist?).with('/etc/sysctl.conf').and_return false
+  end
+end


### PR DESCRIPTION
- removal of deprecations
- fixed the spec tests via generic stub
  (was broken on the latest sysctl versions because of native
   ruby call File.exist? in the sysctl cookbook)
- enabling the latest sysctl cookbook versions
- fixing the chefspec/fauxhai warnings about platform