### PR TITLE
Proper permissions for shadow on debian family

### DIFF
--- a/recipes/minimize_access.rb
+++ b/recipes/minimize_access.rb
@@ -28,11 +28,17 @@ paths.each do |folder|
   end
 end
 
-# shadow must only be accessible to user root
+# limit access to shadow. On debian family group shadow should be able to read it
+# (otherwise screensavers might break etc)
 file '/etc/shadow' do
   owner 'root'
-  group 'root'
-  mode '0600'
+  if node['platform_family'] == 'debian'
+    group 'shadow'
+    mode '0640'
+  else
+    group 'root'
+    mode '0600'
+  end
 end
 
 # su must only be accessible to user and group root

--- a/spec/recipes/minimize_access_spec.rb
+++ b/spec/recipes/minimize_access_spec.rb
@@ -82,8 +82,8 @@ describe 'os-hardening::minimize_access' do
   it 'creates /etc/shadow' do
     is_expected.to create_file('/etc/shadow').with(
       user: 'root',
-      group: 'root',
-      mode: '0600'
+      group: 'shadow',
+      mode: '0640'
     )
   end
 


### PR DESCRIPTION
on debian /etc/shadow should be readable by shadow group.
This is required by screensavers and similar things

This was also part of https://github.com/dev-sec/linux-baseline/pull/44