### PR TITLE
CI: update to ruby 2.4.1 and gem update

### DIFF
--- a/.kitchen.do.local.yml
+++ b/.kitchen.do.local.yml
@@ -4,6 +4,7 @@
 driver:
   name: digitalocean
   size: 512mb
+  region: nyc3
 
 transport:
   ssh_key: '~/.ssh/ci_id_rsa'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,7 @@ AllCops:
   Exclude:
   - vendor/**/*
   - test/**/*
+  TargetRubyVersion: 2.1 # we need this because of chef 12.5.1 support
 Metrics/AbcSize:
   Max: 29
 Metrics/LineLength:
@@ -13,13 +14,13 @@ Metrics/MethodLength:
   Max: 40
 Style/Documentation:
   Enabled: false
-Style/DotPosition:
+Layout/DotPosition:
   EnforcedStyle: trailing
   Enabled: true
 Style/Encoding:
   EnforcedStyle: always
   Enabled: true
-Style/ExtraSpacing:
+Layout/ExtraSpacing:
   Exclude:
     - attributes/default.rb
 Style/HashSyntax:
@@ -30,6 +31,11 @@ Style/NumericLiterals:
   MinDigits: 10
 Style/RegexpLiteral:
   AllowInnerSlashes: true
-Style/SpaceAroundOperators:
+Layout/SpaceAroundOperators:
   Exclude:
     - attributes/default.rb
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*'
+Style/FrozenStringLiteralComment:
+  Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ bundler_args: "--without development"
 dist: trusty
 cache: bundler
 
-rvm: 2.3.3
+rvm: 2.4.1
 
 before_install:
   - gem update --system # see https://github.com/bundler/bundler/issues/5357

--- a/Gemfile
+++ b/Gemfile
@@ -2,21 +2,21 @@
 
 source 'https://rubygems.org'
 
-gem 'berkshelf', '~> 5.3'
-gem 'chef', '~> 12.5'
+gem 'berkshelf', '~> 6.1'
+gem 'chef', '~> 12.5' # chefspec builds get stucked with 13.1
 
 group :test do
-  gem 'chefspec', '~> 5.3.0'
+  gem 'chefspec', '~> 7.1.0'
   gem 'coveralls', require: false
-  gem 'foodcritic', '~> 6.0'
+  gem 'foodcritic', '~> 11.1'
   gem 'rake'
-  gem 'rubocop', '~> 0.46.0'
+  gem 'rubocop', '~> 0.49.0'
   gem 'simplecov', '~> 0.10'
 end
 
 group :development do
   gem 'guard'
-  gem 'guard-foodcritic', '~>2.1'
+  gem 'guard-foodcritic', '~> 3.0'
   gem 'guard-rspec'
   gem 'guard-rubocop'
 end
@@ -29,5 +29,5 @@ group :integration do
 end
 
 group :tools do
-  gem 'github_changelog_generator', '~> 1.12.0'
+  gem 'github_changelog_generator', '~> 1.14'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,6 @@
-#!/usr/bin/env rake
 # encoding: utf-8
+
+# rubocop:disable Style/SymbolArray
 
 require 'foodcritic'
 require 'rspec/core/rake_task'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+
 #
 # Cookbook Name:: os-hardening
 # Attributes:: default
@@ -76,7 +77,7 @@ default['os-hardening']['auth']['allow_homeless']                     = false
 default['os-hardening']['auth']['pam']['passwdqc']['options']           = 'min=disabled,disabled,16,12,8'
 default['os-hardening']['auth']['pam']['cracklib']['options']           = 'try_first_pass retry=3 type='
 default['os-hardening']['auth']['pam']['pwquality']['options']          = 'try_first_pass retry=3 type='
-default['os-hardening']['auth']['root_ttys']                          = %w(console tty1 tty2 tty3 tty4 tty5 tty6)
+default['os-hardening']['auth']['root_ttys']                          = %w[console tty1 tty2 tty3 tty4 tty5 tty6]
 default['os-hardening']['auth']['uid_min']                             = 1000
 default['os-hardening']['auth']['gid_min']                             = 1000
 default['os-hardening']['auth']['sys_uid_min']                         = 100

--- a/attributes/sysctl.rb
+++ b/attributes/sysctl.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+
 #
 # Cookbook Name:: os-hardening
 # Attributes:: sysctl

--- a/libraries/apt_package_extras.rb
+++ b/libraries/apt_package_extras.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+
 #
 # Cookbook Name:: os-hardening
 # Library:: apt_package_extras

--- a/libraries/cookbook_version.rb
+++ b/libraries/cookbook_version.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+
 #
 # Cookbook Name:: os-hardening
 # Library:: cookbook_version

--- a/libraries/gpgcheck.rb
+++ b/libraries/gpgcheck.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+
 #
 # Cookbook Name:: os-hardening
 # Library:: gpgcheck

--- a/libraries/suid_sgid.rb
+++ b/libraries/suid_sgid.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+
 #
 # Cookbook Name:: os-hardening
 # Library:: suid_sgid
@@ -54,10 +55,10 @@ class Chef
       end
 
       def self.remove_suid_sgid_from_unknown(whitelist = [], root = '/', dry_run = false)
-        all_suid_sgid_files = find_all_suid_sgid_files(root).select do |file|
+        all_suid_sgid_files = find_all_suid_sgid_files(root).reject do |file|
           in_whitelist = whitelist.include?(file)
           Chef::Log.info "suid_sgid: Whitelisted file '#{file}', not altering SUID/SGID bit" if in_whitelist && !dry_run
-          !in_whitelist
+          in_whitelist
         end
 
         all_suid_sgid_files.each do |file|

--- a/metadata.rb
+++ b/metadata.rb
@@ -19,10 +19,12 @@
 name             'os-hardening'
 maintainer       'Dominik Richter'
 maintainer_email 'dominik.richter@googlemail.com'
-license          'Apache 2.0'
+license          'Apache-2.0'
 description      'Installs and configures operating system hardening'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '2.0.1'
+
+chef_version '>= 12.5' if respond_to?(:chef_version)
 
 supports 'ubuntu', '>= 12.04'
 supports 'debian', '>= 6.0'

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8 # ~FC061
+
 #
 # Copyright 2014, Deutsche Telekom AG
 #

--- a/recipes/apt.rb
+++ b/recipes/apt.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+
 #
 # Cookbook Name: os-hardening
 # Recipe: apt.rb

--- a/recipes/auditd.rb
+++ b/recipes/auditd.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+
 #
 # Cookbook Name: os-hardening
 # Recipe: auditd.rb

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+
 #
 # Cookbook Name: os-hardening
 # Recipe: default

--- a/recipes/limits.rb
+++ b/recipes/limits.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+
 #
 # Cookbook Name: os-hardening
 # Recipe: limits.rb

--- a/recipes/login_defs.rb
+++ b/recipes/login_defs.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+
 #
 # Cookbook Name: os-hardening
 # Recipe: login_defs.rb

--- a/recipes/minimize_access.rb
+++ b/recipes/minimize_access.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+
 #
 # Cookbook Name: os-hardening
 # Recipe: minimize_access
@@ -20,7 +21,7 @@
 
 # remove write permissions from path folders ($PATH) for all regular users
 # this prevents changing any system-wide command from normal users
-paths = %w(/usr/local/sbin /usr/local/bin /usr/sbin /usr/bin /sbin /bin) + node['os-hardening']['env']['extra_user_paths']
+paths = %w[/usr/local/sbin /usr/local/bin /usr/sbin /usr/bin /sbin /bin] + node['os-hardening']['env']['extra_user_paths']
 paths.each do |folder|
   execute "remove write permission from #{folder}" do
     command "chmod go-w -R #{folder}"

--- a/recipes/packages.rb
+++ b/recipes/packages.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+
 #
 # Cookbook Name: os-hardening
 # Recipe: packages.rb

--- a/recipes/pam.rb
+++ b/recipes/pam.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+
 #
 # Cookbook Name: os-hardening
 # Recipe: pam.rb

--- a/recipes/profile.rb
+++ b/recipes/profile.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+
 #
 # Cookbook Name: os-hardening
 # Recipe: profile.rb

--- a/recipes/securetty.rb
+++ b/recipes/securetty.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+
 #
 # Cookbook Name: os-hardening
 # Recipe: securetty

--- a/recipes/suid_sgid.rb
+++ b/recipes/suid_sgid.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+
 #
 # Cookbook Name: os-hardening
 # Recipe: suid_sgid

--- a/recipes/sysctl.rb
+++ b/recipes/sysctl.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+
 #
 # Cookbook Name: os-hardening
 # Recipe: sysctl

--- a/recipes/yum.rb
+++ b/recipes/yum.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+
 #
 # Cookbook Name: os-hardening
 # Recipe: pack_yum.rb
@@ -42,7 +43,7 @@ end
 if node['os-hardening']['security']['packages']['clean']
 
   # remove unused repos
-  %w(CentOS-Debuginfo CentOS-Media CentOS-Vault).each do |repo|
+  %w[CentOS-Debuginfo CentOS-Media CentOS-Vault].each do |repo|
     yum_repository repo do
       action :remove
     end

--- a/spec/recipes/auditd_spec.rb
+++ b/spec/recipes/auditd_spec.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+
 #
 # Copyright 2017, Artem Sidorenko
 #

--- a/spec/recipes/default_spec.rb
+++ b/spec/recipes/default_spec.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+
 #
 # Copyright 2014, Deutsche Telekom AG
 #
@@ -26,9 +27,9 @@ describe 'os-hardening::default' do
       node.normal['cpu']['0']['vendor_id'] = 'GenuineIntel'
       node.normal['env']['extra_user_paths'] = []
 
-      paths = %w(
+      paths = %w[
         /usr/local/sbin /usr/local/bin /usr/sbin /usr/bin /sbin /bin
-      ) + node['env']['extra_user_paths']
+      ] + node['env']['extra_user_paths']
       paths.each do |folder|
         stub_command(
           "find #{folder}  -perm -go+w -type f | wc -l | egrep '^0$'"

--- a/spec/recipes/limits_spec.rb
+++ b/spec/recipes/limits_spec.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+
 #
 # Copyright 2014, Deutsche Telekom AG
 #

--- a/spec/recipes/login_defs_spec.rb
+++ b/spec/recipes/login_defs_spec.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+
 #
 # Copyright 2014, Deutsche Telekom AG
 #

--- a/spec/recipes/minimize_access_spec.rb
+++ b/spec/recipes/minimize_access_spec.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+
 #
 # Copyright 2014, Deutsche Telekom AG
 #

--- a/spec/recipes/pam_spec.rb
+++ b/spec/recipes/pam_spec.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+
 #
 # Copyright 2014, Deutsche Telekom AG
 #

--- a/spec/recipes/profile_spec.rb
+++ b/spec/recipes/profile_spec.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+
 #
 # Copyright 2014, Deutsche Telekom AG
 #

--- a/spec/recipes/securetty_spec.rb
+++ b/spec/recipes/securetty_spec.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+
 #
 # Copyright 2014, Deutsche Telekom AG
 #

--- a/spec/recipes/suid_sgid_spec.rb
+++ b/spec/recipes/suid_sgid_spec.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+
 #
 # Copyright 2014, Deutsche Telekom AG
 #

--- a/spec/recipes/sysctl_spec.rb
+++ b/spec/recipes/sysctl_spec.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+
 #
 # Copyright 2014, Deutsche Telekom AG
 #

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+
 #
 # Copyright 2014, Deutsche Telekom AG
 #


### PR DESCRIPTION
Chef 13 is also using ruby 2.4.1 in the omnibus packages

There are problems with Chef 13.1 in the chefspec tests. The builds are getting stucked without any specific reason. I'll investigate this further...