### PR TITLE
Fix: do not touch exec-shield on RHEL 7

### DIFF
--- a/attributes/sysctl.rb
+++ b/attributes/sysctl.rb
@@ -92,10 +92,12 @@ default['sysctl']['params']['net']['ipv6']['conf']['all']['accept_ra'] = 0
 default['sysctl']['params']['net']['ipv6']['conf']['default']['accept_ra'] = 0
 
 # ExecShield protection against buffer overflows
-# unless node['platform'] == "ubuntu" # ["nx"].include?(node['cpu'][0]['flags']) or
 case node['platform_family']
 when 'rhel', 'fedora'
-  default['sysctl']['params']['kernel']['exec-shield'] = 1
+  # on RHEL 7 its enabled per default and can't be disabled
+  if node['platform_version'].to_f < 7
+    default['sysctl']['params']['kernel']['exec-shield'] = 1
+  end
 end
 
 # Virtual memory regions protection

--- a/metadata.rb
+++ b/metadata.rb
@@ -32,7 +32,9 @@ supports 'centos', '>= 5.0'
 supports 'redhat', '>= 5.0'
 supports 'oracle', '>= 6.4'
 
-depends 'sysctl', '>= 0.6.0'
+# temporary version pinning of sysctl
+# https://github.com/dev-sec/chef-os-hardening/issues/166#issuecomment-322433264
+depends 'sysctl', '<= 0.9.0'
 depends 'compat_resource', '>= 12.16.3'
 
 recipe 'os-hardening::default', 'harden the operating system (all recipes)'


### PR DESCRIPTION
as its enabled per default and can't be switched off

Introduction of temporary version pinning for sysctl cookbook,
see https://github.com/dev-sec/chef-os-hardening/issues/166#issuecomment-322433264

Fixes GH-166