### PR TITLE
Update of testing boxes/images

### DIFF
--- a/.kitchen.do.local.yml
+++ b/.kitchen.do.local.yml
@@ -13,8 +13,8 @@ transport:
 platforms:
 - name: ubuntu-14-04-x64
 - name: ubuntu-16-04-x64
-- name: centos-6-5-x64
-- name: centos-7-0-x64
+- name: centos-6-x64
+- name: centos-7-x64
 - name: debian-7-x64
 - name: debian-8-x64
 - name: fedora-24-x64

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -6,9 +6,9 @@ driver:
 platforms:
 - name: ubuntu-14.04
 - name: ubuntu-16.04
-- name: centos-6.8
-- name: centos-7.3
-- name: oracle-6.8
+- name: centos-6.9
+- name: centos-7.4
+- name: oracle-6.9
 - name: oracle-7.3
 - name: debian-7.11
 - name: debian-8.6


### PR DESCRIPTION
Lets use the generic centos-7 images on DO, they point
always to the latest distro release