### PR TITLE
Selinux enforcing support for RHEL/Centos

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -42,3 +42,12 @@ suites:
     - path: test/integration/default
     attributes:
       kernel_modules_disabled: 1
+- name: selinux_enabled
+  run_list:
+  - recipe[os-hardening::default]
+  includes:
+    - centos-7.3
+  attributes:
+    os-hardening:
+      security:
+        selinux_mode: enforcing

--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ It will not:
   * ypserv ([NSA](http://www.nsa.gov/ia/_files/os/redhat/rhel5-guide-i731.pdf), Chapter 3.2.4)
   * telnet-server ([NSA](http://www.nsa.gov/ia/_files/os/redhat/rhel5-guide-i731.pdf), Chapter 3.2.2)
   * rsh-server ([NSA](http://www.nsa.gov/ia/_files/os/redhat/rhel5-guide-i731.pdf), Chapter 3.2.3)
+* `['os-hardening']['security']['selinux_mode'] = 'unmanaged'`
+  set to `unmanaged` if you want to let selinux configuration as it is. Set to `enforcing` to enforce or `permissive` to permissive SELinux.
 
 ## Usage
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -116,6 +116,9 @@ default['os-hardening']['security']['packages']['list']               = [
   'rsh-server'
 ]
 
+# SELinux enforcing (enforcing, permissive, unmanaged)
+default['os-hardening']['security']['selinux_mode']                      = 'unmanaged'
+
 # SYSTEM CONFIGURATION
 # ====================
 # These are not meant to be modified by the user

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -30,3 +30,4 @@ include_recipe('os-hardening::securetty')
 include_recipe('os-hardening::suid_sgid') if node['os-hardening']['security']['suid_sgid']['enforce']
 include_recipe('os-hardening::sysctl')
 include_recipe('os-hardening::auditd')
+include_recipe('os-hardening::selinux') if node['platform_family'] == 'rhel' || node['platform_family'] == 'fedora'

--- a/recipes/selinux.rb
+++ b/recipes/selinux.rb
@@ -1,0 +1,51 @@
+# encoding: utf-8
+
+#
+# Cookbook Name: os-hardening
+# Recipe: selinux.rv
+#
+# Copyright 2017, Deutsche Telekom AG
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# SELinux enforcing support
+
+case node['platform_family']
+when 'rhel', 'fedora'
+  unless node['os-hardening']['security']['selinux_mode'] == 'unmanaged'
+    semode = case node['os-hardening']['security']['selinux_mode']
+             when 'enforcing'
+               'Enforcing'
+             when 'permissive'
+               'Permissive'
+             else
+               raise "Unsupported selinuxmode #{node['os-hardening']['security']['selinux_mode']}"
+             end
+
+    execute "Set selinux mode to #{semode}" do
+      command "setenforce #{semode}"
+      not_if "getenforce | grep -F #{semode}"
+    end
+
+    template '/etc/selinux/config' do
+      source 'rhel_selinuxconfig.erb'
+      mode 0644
+      owner 'root'
+      group 'root'
+      variables selinux_mode: node['os-hardening']['security']['selinux_mode']
+    end
+  end
+else
+  raise "Selinux recipe is not supported on the platform family #{node['platform_family']}"
+end

--- a/templates/default/rhel_selinuxconfig.erb
+++ b/templates/default/rhel_selinuxconfig.erb
@@ -1,0 +1,15 @@
+<% node['config_disclaimer'].to_s.split("\n").each do |l| %>
+# <%= l %>
+<% end %>
+
+# This file controls the state of SELinux on the system.
+# SELINUX= can take one of these three values:
+#     enforcing - SELinux security policy is enforced.
+#     permissive - SELinux prints warnings instead of enforcing.
+#     disabled - No SELinux policy is loaded.
+SELINUX=<%= @selinux_mode %>
+# SELINUXTYPE= can take one of these three values:
+#     targeted - Targeted processes are protected,
+#     minimum - Modification of targeted policy. Only selected processes are protected.
+#     mls - Multi Level Security protection.
+SELINUXTYPE=targeted

--- a/test/integration/default/inspec.yml
+++ b/test/integration/default/inspec.yml
@@ -1,4 +1,5 @@
 name: os-hardening-integration-tests
+version: 1.0.0
 depends:
   - name: linux-baseline
     url: https://github.com/dev-sec/linux-baseline

--- a/test/integration/selinux_enabled/controls/tests.rb
+++ b/test/integration/selinux_enabled/controls/tests.rb
@@ -1,0 +1,16 @@
+include_controls 'os-hardening-integration-tests'
+
+control 'SELinux-01' do
+  impact 1.0
+  title 'Verify SELinux enforcing'
+  desc 'Verify SELinux enforcing'
+
+  describe file('/etc/selinux/config') do
+    its('content') { should include 'SELINUX=enforcing' }
+  end
+
+  describe command('getenforce') do
+    its('stdout') { should eq "Enforcing\n" }
+    its('stderr') { should eq '' }
+  end
+end

--- a/test/integration/selinux_enabled/inspec.yml
+++ b/test/integration/selinux_enabled/inspec.yml
@@ -1,0 +1,5 @@
+name: os-hardening-integration-tests-selinux
+version: 1.0.0
+depends:
+  - name: os-hardening-integration-tests
+    path: test/integration/default


### PR DESCRIPTION
lets have an attribute for enforcing or permissiving SELinuxon RHEL/Centos.
Implementation like suggested in issue: https://github.com/dev-sec/chef-os-hardening/issues/106
