### PR TITLE
Using the same names for platforms for different drivers

### DIFF
--- a/.kitchen.do.local.yml
+++ b/.kitchen.do.local.yml
@@ -11,11 +11,27 @@ transport:
   max_wait_until_ready: 30
 
 platforms:
-- name: ubuntu-14-04-x64
-- name: ubuntu-16-04-x64
-- name: centos-6-x64
-- name: centos-7-x64
-- name: debian-7-x64
-- name: debian-8-x64
-- name: fedora-24-x64
-- name: fedora-25-x64
+- name: ubuntu-14-04
+  driver_config:
+    image: ubuntu-14-04-x64
+- name: ubuntu-16-04
+  driver_config:
+    image: ubuntu-16-04-x64
+- name: centos-6
+  driver_config:
+    image: centos-6-x64
+- name: centos-7
+  driver_config:
+    image: centos-7-x64
+- name: debian-7
+  driver_config:
+    image: debian-7-x64
+- name: debian-8
+  driver_config:
+    image: debian-8-x64
+- name: fedora-25
+  driver_config:
+    image: fedora-25-x64
+- name: fedora-26
+  driver_config:
+    image: fedora-26-x64

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -4,17 +4,39 @@ driver:
   name: vagrant
 
 platforms:
-- name: ubuntu-14.04
-- name: ubuntu-16.04
-- name: centos-6.9
-- name: centos-7.4
-- name: oracle-6.9
-- name: oracle-7.3
-- name: debian-7.11
-- name: debian-8.6
-- name: fedora-24
+- name: ubuntu-14-04
+  driver_config:
+    box: bento/ubuntu-14.04
+- name: ubuntu-16-04
+  driver_config:
+    box: bento/ubuntu-16.04
+- name: centos-6
+  driver_config:
+    box: bento/centos-6.9
+- name: centos-7
+  driver_config:
+    box: bento/centos-7.4
+- name: oracle-6
+  driver_config:
+    box: bento/oracle-6.9
+- name: oracle-7
+  driver_config:
+    box: bento/oracle-7.3
+- name: debian-7
+  driver_config:
+    box: bento/debian-7.11
+- name: debian-8
+  driver_config:
+    box: bento/debian-8.6
 - name: fedora-25
-- name: opensuse-leap-42.1
+  driver_config:
+    box: bento/fedora-25
+- name: fedora-26
+  driver_config:
+    box: bento/fedora-26
+- name: opensuse-leap-42
+  driver_config:
+    box: bento/opensuse-leap-42.1
 
 provisioner:
   name: chef_solo
@@ -46,7 +68,7 @@ suites:
   run_list:
   - recipe[os-hardening::default]
   includes:
-    - centos-7.3
+    - centos-7
   attributes:
     os-hardening:
       security:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,8 @@ env:
  - INSTANCE=centos-7 CHEF_VERSION=12.5.1
  - INSTANCE=debian-7
  - INSTANCE=debian-8
- - INSTANCE=fedora-24
  - INSTANCE=fedora-25
+ - INSTANCE=fedora-26
 
 script:
   -  bundle exec rake prepare_do_env kitchen KITCHEN_LOCAL_YAML=.kitchen.do.local.yml
@@ -35,8 +35,8 @@ matrix:
   - env: INSTANCE=centos-7 CHEF_VERSION=12.5.1
   - env: INSTANCE=debian-7
   - env: INSTANCE=debian-8
-  - env: INSTANCE=fedora-24
   - env: INSTANCE=fedora-25
+  - env: INSTANCE=fedora-26
   include:
     - env: UNIT_AND_LINT=1
       script:


### PR DESCRIPTION
This allows easy usage and testing of different suites locally and in
the CI (DO)

Also updating Fedora platforms. Fedora 24 is EOL.

Signed-off-by: Artem Sidorenko <artem@posteo.de>