### PR TITLE
Fix: lets use generic package resource

### DIFF
--- a/recipes/yum.rb
+++ b/recipes/yum.rb
@@ -51,7 +51,7 @@ if node['os-hardening']['security']['packages']['clean']
 
   # remove packages
   node['os-hardening']['security']['packages']['list'].each do |pkg|
-    yum_package pkg do
+    package pkg do
       action :purge
     end
   end


### PR DESCRIPTION
On Fedora dnf is used and not yum. Lets chef decide which provider to
use

Signed-off-by: Artem Sidorenko <artem@posteo.de>