### PR TITLE
Support running on LXD/LXC guests.

### DIFF
--- a/recipes/auditd.rb
+++ b/recipes/auditd.rb
@@ -19,4 +19,7 @@
 # limitations under the License.
 #
 
-package node['os-hardening']['packages']['auditd']
+package node['os-hardening']['packages']['auditd'] do
+  # Do not install auditd within an LXC guest as it requires kernel access
+  not_if { node['virtualization']['system'] == 'lxd' && node['virtualization']['role'] == 'guest' }
+end

--- a/recipes/sysctl.rb
+++ b/recipes/sysctl.rb
@@ -20,6 +20,13 @@
 # limitations under the License.
 #
 
+# Do not run the sysctl recipe on LXD/LXC containers as the values cannot be
+# changed from within a container.
+if node['virtualization']['system'] == 'lxd' && node['virtualization']['role'] == 'guest'
+  Chef::Log.warn "Skipping #{cookbook_name}::#{recipe_name} recipe; Node is an LXD Guest Container."
+  return
+end
+
 # default attributes
 # We can not set this kind of defaults in the attribute files
 # as we react on value of other attributes


### PR DESCRIPTION
Sysctl parameters are not valid within the context of an LXD/LXC container as they are inherited from the host kernel. Attempting to run this recipe within an LXD/LXC container will result in a failure to converge. Additionally, auditd is not available within a container either, and probably should be managed from the host level.
    
_Disclaimer_: 
Using this cookbook in an LXC container will not reduce nor eliminate the inherent security risks of running containers. This change is simply to allow the cookbook to configure the guest OS in the manner consistent with good security practices.
