### PR TITLE
Remove dependency on compat_resource

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,10 @@ before_install:
 env:
  - INSTANCE=ubuntu-14-04
  - INSTANCE=ubuntu-16-04
- - INSTANCE=ubuntu-16-04 CHEF_VERSION=12.5.1
+ - INSTANCE=ubuntu-16-04 CHEF_VERSION=12.14.60
  - INSTANCE=centos-6
  - INSTANCE=centos-7
- - INSTANCE=centos-7 CHEF_VERSION=12.5.1
+ - INSTANCE=centos-7 CHEF_VERSION=12.14.60
  - INSTANCE=debian-7
  - INSTANCE=debian-8
  - INSTANCE=fedora-25
@@ -29,10 +29,10 @@ matrix:
   allow_failures: # allow failues of integration tests as the forks might miss the DO token
   - env: INSTANCE=ubuntu-14-04
   - env: INSTANCE=ubuntu-16-04
-  - env: INSTANCE=ubuntu-16-04 CHEF_VERSION=12.5.1
+  - env: INSTANCE=ubuntu-16-04 CHEF_VERSION=12.14.60
   - env: INSTANCE=centos-6
   - env: INSTANCE=centos-7
-  - env: INSTANCE=centos-7 CHEF_VERSION=12.5.1
+  - env: INSTANCE=centos-7 CHEF_VERSION=12.14.60
   - env: INSTANCE=debian-7
   - env: INSTANCE=debian-8
   - env: INSTANCE=fedora-25

--- a/metadata.rb
+++ b/metadata.rb
@@ -35,7 +35,6 @@ supports 'oracle', '>= 6.4'
 # temporary version pinning of sysctl
 # https://github.com/dev-sec/chef-os-hardening/issues/166#issuecomment-322433264
 depends 'sysctl', '<= 0.9.0'
-depends 'compat_resource', '>= 12.16.3'
 
 recipe 'os-hardening::default', 'harden the operating system (all recipes)'
 recipe 'os-hardening::limits', 'prevent core dumps'


### PR DESCRIPTION
Remove dependency on compat_resource (deprecated). Fixes #186, but may break older clients