### PR TITLE
Fix fedora shadow permissions

### DIFF
--- a/recipes/minimize_access.rb
+++ b/recipes/minimize_access.rb
@@ -34,7 +34,7 @@ end
 file '/etc/shadow' do
   owner 'root'
   case node['platform_family']
-  when 'rhel'
+  when 'rhel', 'fedora'
     group 'root'
     mode '0000'
   when 'debian'


### PR DESCRIPTION
Fedora belongs in our tests to the RH family,
lets make it explicitely here, as ohai detects platform_family on fedora
as 'fedora' and not 'rhel'.

See https://github.com/dev-sec/linux-baseline/pull/82 for reference

Signed-off-by: Artem Sidorenko <artem@posteo.de>