### PR TITLE
Remove deprecated sysctl.d config and unpin sysctl

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -32,7 +32,7 @@ supports 'centos', '>= 5.0'
 supports 'redhat', '>= 5.0'
 supports 'oracle', '>= 6.4'
 
-depends 'sysctl'
+depends 'sysctl', '> 0.9.0'
 depends 'compat_resource', '>= 12.16.3'
 
 recipe 'os-hardening::default', 'harden the operating system (all recipes)'

--- a/metadata.rb
+++ b/metadata.rb
@@ -32,9 +32,7 @@ supports 'centos', '>= 5.0'
 supports 'redhat', '>= 5.0'
 supports 'oracle', '>= 6.4'
 
-# temporary version pinning of sysctl
-# https://github.com/dev-sec/chef-os-hardening/issues/166#issuecomment-322433264
-depends 'sysctl', '<= 0.9.0'
+depends 'sysctl'
 depends 'compat_resource', '>= 12.16.3'
 
 recipe 'os-hardening::default', 'harden the operating system (all recipes)'

--- a/recipes/sysctl.rb
+++ b/recipes/sysctl.rb
@@ -185,3 +185,11 @@ else
     variables filesystems: node['os-hardening']['security']['kernel']['disable_filesystems']
   end
 end
+
+# Delete conf_file from previous version of sysctl, if it exists
+if node['sysctl'].attribute?('conf_file')
+  file node['sysctl']['conf_file'] do
+    action :delete
+  end
+end
+


### PR DESCRIPTION
Fixes #192 . Simply remove the file in the deprecated sysctl attribute since it will be recreated in its new location by sysctl. File should simply ignore this if the file doesn't exist.