### PR TITLE
add basic support for amazon linux

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -37,6 +37,9 @@ platforms:
 - name: opensuse-leap-42
   driver_config:
     box: bento/opensuse-leap-42.1
+- name: amzn2
+  driver_config:
+    box: stakahashi/amazonlinux2
 
 provisioner:
   name: chef_solo

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -21,7 +21,7 @@
 
 # Define the packages based on operating system
 case node['platform_family']
-when 'rhel', 'fedora'
+when 'rhel', 'fedora', 'amazon'
   default['os-hardening']['packages']['pam_ccreds'] = 'pam_ccreds'
   default['os-hardening']['packages']['pam_passwdqc'] = 'pam_passwdqc'
   default['os-hardening']['packages']['pam_cracklib'] = 'pam_cracklib'
@@ -84,7 +84,7 @@ default['os-hardening']['auth']['sys_gid_max']                         = 999
 
 # RH has a bit different defaults on some places
 case node['platform_family']
-when 'rhel'
+when 'rhel', 'amazon'
   default['os-hardening']['env']['umask'] = '077'
   default['os-hardening']['auth']['sys_uid_min'] = 201
   default['os-hardening']['auth']['sys_gid_min'] = 201

--- a/metadata.rb
+++ b/metadata.rb
@@ -26,6 +26,7 @@ version          '3.0.0'
 
 chef_version '>= 12.5' if respond_to?(:chef_version)
 
+supports 'amazon'
 supports 'ubuntu', '>= 12.04'
 supports 'debian', '>= 6.0'
 supports 'centos', '>= 5.0'

--- a/recipes/minimize_access.rb
+++ b/recipes/minimize_access.rb
@@ -34,7 +34,7 @@ end
 file '/etc/shadow' do
   owner 'root'
   case node['platform_family']
-  when 'rhel', 'fedora'
+  when 'rhel', 'fedora', 'amazon'
     group 'root'
     mode '0000'
   when 'debian'

--- a/recipes/packages.rb
+++ b/recipes/packages.rb
@@ -27,6 +27,6 @@ end
 
 # do package config for rhel-family
 case node['platform_family']
-when 'rhel', 'fedora'
+when 'rhel', 'fedora', 'amazon'
   include_recipe('os-hardening::yum')
 end

--- a/recipes/selinux.rb
+++ b/recipes/selinux.rb
@@ -22,7 +22,7 @@
 # SELinux enforcing support
 
 case node['platform_family']
-when 'rhel', 'fedora'
+when 'rhel', 'fedora', 'amazon'
   unless node['os-hardening']['security']['selinux_mode'] == 'unmanaged'
     semode = case node['os-hardening']['security']['selinux_mode']
              when 'enforcing'

--- a/recipes/sysctl.rb
+++ b/recipes/sysctl.rb
@@ -150,7 +150,7 @@ end
 # NSA 2.2.4.1 Set Daemon umask
 # do config for rhel-family
 case node['platform_family']
-when 'rhel', 'fedora'
+when 'rhel', 'fedora', 'amazon'
   template '/etc/sysconfig/init' do
     source 'rhel_sysconfig_init.erb'
     mode 0544


### PR DESCRIPTION
This PR adds support for Amazon Linux. The biggest change is the switch to the latest sysctl cookbook. This was pinned previously by @artem-sidorenko and discussed https://github.com/dev-sec/chef-os-hardening/issues/166#issuecomment-322433264

Are there any side-effects by moving to the latest version @artem-sidorenko ?

We may consider merging #193 first

Chef Omnibus install has an issue with Amazon Linux as described here https://github.com/chef/omnitruck/issues/346