### PR TITLE
Feature/allow setting template source

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@ It will not:
   true if you want to use strong password checking in PAM using passwdqc
 * `['os-hardening']['auth']['pam']['passwdqc']['options'] = "min=disabled,disabled,16,12,8"`
   set to any option line (as a string) that you want to pass to passwdqc
+* `['os-hardening']['auth']['pam']['passwdqc']['template_cookbook'] = 'os-hardening'`
+  set to the name of the cookbook from which the template is obtained for the `/usr/share/pam-configs/passwdqc` file
+* `['os-hardening']['auth']['pam']['tally2']['template_cookbook'] = 'os-hardening'`
+  set to the name of the cookbook from which the template is obtained for the `/usr/share/pam-configs/tally2` file
+* `['os-hardening']['auth']['pam']['system-auth']['template_cookbook'] = 'os-hardening'`
+  set to the name of the cookbook from which the template is obtained for the `/etc/pam.d/system-auth-ac` file
 * `['os-hardening']['security']['users']['allow'] = []`
   list of things, that a user is allowed to do. May contain: `change_user`
 * `['os-hardening']['security']['kernel']['enable_module_loading'] = true`

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -76,6 +76,9 @@ default['os-hardening']['auth']['allow_homeless']                     = false
 default['os-hardening']['auth']['pam']['passwdqc']['options']           = 'min=disabled,disabled,16,12,8'
 default['os-hardening']['auth']['pam']['cracklib']['options']           = 'try_first_pass retry=3 type='
 default['os-hardening']['auth']['pam']['pwquality']['options']          = 'try_first_pass retry=3 type='
+default['os-hardening']['auth']['pam']['tally2']['template_cookbook']        = 'os-hardening'
+default['os-hardening']['auth']['pam']['passwdqc']['template_cookbook']      = 'os-hardening'
+default['os-hardening']['auth']['pam']['system-auth']['template_cookbook']   = 'os-hardening'
 default['os-hardening']['auth']['root_ttys']                          = %w[console tty1 tty2 tty3 tty4 tty5 tty6]
 default['os-hardening']['auth']['uid_min']                             = 1000
 default['os-hardening']['auth']['gid_min']                             = 1000

--- a/recipes/pam.rb
+++ b/recipes/pam.rb
@@ -50,6 +50,7 @@ when 'debian'
     # configure passwdqc via central module:
     template passwdqc_path do
       source 'pam_passwdqc.erb'
+      cookbook node['os-hardening']['auth']['pam']['passwdqc']['template_cookbook']
       mode 0640
       owner 'root'
       group 'root'
@@ -78,6 +79,7 @@ when 'debian'
 
     template tally2_path do
       source 'pam_tally2.erb'
+      cookbook node['os-hardening']['auth']['pam']['tally2']['template_cookbook']
       mode 0640
       owner 'root'
       group 'root'
@@ -122,6 +124,7 @@ when 'rhel', 'fedora'
   # configure passwdqc and tally via central system-auth confic:
   template '/etc/pam.d/system-auth-ac' do
     source 'rhel_system_auth.erb'
+    cookbook node['os-hardening']['auth']['pam']['system-auth']['template_cookbook']
     mode 0640
     owner 'root'
     group 'root'


### PR DESCRIPTION
This update allows users to specify an alternate source cookbook for the PAM templates. I needed this because I use FreeIPA, which updates the PAM configuration. When running the dev-sec cookbook, the IPA changes are overwritten. 

I had two choices when making the update
1. add the use of arbitrary attributes and not use alternative cookbooks
1. allow using any configuration via an alternative cookbook

I chose the second option as it involves lower risk to existing systems / settings. For unit testing, there are no tests related to these templates, so I did not add tests / make changes. I would be willing to add those if needed, however.

For integration testing, I ran the tests to confirm existing functionality remains unchanged, however I only did so on my local as I don't have a DO account to run the full gamut of tests. I'm open to alternative means of running the integration tests. 

To truly run integration tests fully, I would need to add two things:
1. a new suite that uses an alternative cookbook to run dev-sec (this would effectively double the number of tests and possibly the amount of time required depending on whether the test suites are serial or parallel)
1. a small cookbook under test/integration that provides the alternative cookbook

I wasn't sure if the team wanted to add all those extra pieces, so I haven't done that yet, but if so desired, I could add the new suite and test cookbook.