### PR TITLE
Lazy pin the sysctl major version

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -33,7 +33,7 @@ supports 'centos', '>= 5.0'
 supports 'redhat', '>= 5.0'
 supports 'oracle', '>= 6.4'
 
-depends 'sysctl', '>= 0.10.0'
+depends 'sysctl', '~> 0.10'
 
 recipe 'os-hardening::default', 'harden the operating system (all recipes)'
 recipe 'os-hardening::limits', 'prevent core dumps'


### PR DESCRIPTION
The new major release 1.0.0 does not have recipes anymore, we will have
to reflect that. Pinning the major version for now.

Signed-off-by: Artem Sidorenko <artem@posteo.de>