### PR TITLE
Update kitchen config for more platforms

### DIFF
--- a/.kitchen.do.yml
+++ b/.kitchen.do.yml
@@ -23,9 +23,6 @@ platforms:
 - name: centos-7
   driver_config:
     image: centos-7-x64
-- name: debian-7
-  driver_config:
-    image: debian-7-x64
 - name: debian-8
   driver_config:
     image: debian-8-x64

--- a/.kitchen.do.yml
+++ b/.kitchen.do.yml
@@ -17,6 +17,9 @@ platforms:
 - name: ubuntu-16-04
   driver_config:
     image: ubuntu-16-04-x64
+- name: ubuntu-18-04
+  driver_config:
+    image: ubuntu-18-04-x64
 - name: centos-6
   driver_config:
     image: centos-6-x64
@@ -26,6 +29,9 @@ platforms:
 - name: debian-8
   driver_config:
     image: debian-8-x64
+- name: debian-9
+  driver_config:
+    image: debian-9-x64
 - name: fedora-26
   driver_config:
     image: fedora-26-x64

--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -17,60 +17,6 @@ verifier:
   sudo: true
 
 platforms:
-- name: ubuntu-14-04
-  driver:
-    image: ubuntu:14.04
-- name: ubuntu-16-04
-  driver:
-    image: ubuntu:16.04
-    intermediate_instructions:
-    - RUN /usr/bin/apt-get update
-    pid_one_command: /bin/systemd
-- name: centos-6
-  driver:
-    image: centos:6
-    intermediate_instructions:
-      - RUN yum install -y initscripts
-- name: centos-7
-  driver:
-    image: centos:7
-    pid_one_command: /usr/lib/systemd/systemd
-- name: oracle-6
-  driver:
-    image: oraclelinux:6
-- name: oracle-7
-  driver:
-    image: oraclelinux:7
-    pid_one_command: /usr/lib/systemd/systemd
-- name: debian-7
-  driver:
-    image: debian:7
-    intermediate_instructions:
-    - RUN /usr/bin/apt-get update
-    - RUN /usr/bin/apt-get install -y procps
-- name: debian-8
-  driver:
-    image: debian:8
-    intermediate_instructions:
-    - RUN /usr/bin/apt-get update
-    - RUN /usr/bin/apt-get install -y procps
-    pid_one_command: /bin/systemd
-- name: fedora-26
-  driver:
-    image: fedora:26
-    pid_one_command: /usr/lib/systemd/systemd
-    intermediate_instructions:
-    - RUN dnf install -y yum
-- name: fedora-27
-  driver:
-    image: fedora:27
-    pid_one_command: /usr/lib/systemd/systemd
-    intermediate_instructions:
-    - RUN dnf install -y yum
-- name: opensuse-42
-  driver:
-    image: opensuse:leap
-    pid_one_command: /usr/lib/systemd/systemd
 - name: amazonlinux-1
   driver:
     image: dokken/amazonlinux
@@ -79,3 +25,64 @@ platforms:
   driver:
     image: dokken/amazonlinux-2
     pid_one_command: /usr/lib/systemd/systemd
+- name: centos-6
+  driver:
+    image: dokken/centos-6
+    pid_one_command: /sbin/init
+- name: centos-7
+  driver:
+    image: dokken/centos-7
+    pid_one_command: /usr/lib/systemd/systemd
+- name: oracle-6
+  driver:
+    image: oraclelinux:6
+- name: oracle-7
+  driver:
+    image: oraclelinux:7
+    pid_one_command: /usr/lib/systemd/systemd
+- name: debian-8
+  driver:
+    image: dokken/debian-8
+    intermediate_instructions:
+    - RUN /usr/bin/apt-get update
+    pid_one_command: /bin/systemd
+- name: debian-9
+  driver:
+    image: dokken/debian-9
+    intermediate_instructions:
+    - RUN /usr/bin/apt-get update
+    pid_one_command: /bin/systemd
+- name: fedora-26
+  driver:
+    image: dokken/fedora-26
+    pid_one_command: /usr/lib/systemd/systemd
+    intermediate_instructions:
+    - RUN dnf install -y yum
+- name: fedora-27
+  driver:
+    image: dokken/fedora-27
+    pid_one_command: /usr/lib/systemd/systemd
+    intermediate_instructions:
+    - RUN dnf install -y yum
+- name: opensuse-42
+  driver:
+    image: dokken/opensuse-leap
+    pid_one_command: /bin/systemd
+- name: ubuntu-14-04
+  driver:
+    image: dokken/ubuntu-14.04
+    pid_one_command: /sbin/init
+    intermediate_instructions:
+      - RUN /usr/bin/apt-get update
+- name: ubuntu-16-04
+  driver:
+    image: dokken/ubuntu-16.04
+    pid_one_command: /bin/systemd
+    intermediate_instructions:
+      - RUN /usr/bin/apt-get update
+- name: ubuntu-18-04
+  driver:
+    image: dokken/ubuntu-18.04
+    pid_one_command: /bin/systemd
+    intermediate_instructions:
+      - RUN /usr/bin/apt-get update

--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -4,9 +4,7 @@
 driver:
   name: dokken
   privileged: true # because Docker and SystemD/Upstart
-<% if ENV['CHEF_VERSION'] %>
-  chef_version: <%= ENV['CHEF_VERSION'] %>
-<% end %>
+  chef_version: <%= ENV['CHEF_VERSION'] || 'current' %>
 
 transport:
   name: dokken

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -22,9 +22,6 @@ platforms:
 - name: oracle-7
   driver_config:
     box: bento/oracle-7.3
-- name: debian-7
-  driver_config:
-    box: bento/debian-7.11
 - name: debian-8
   driver_config:
     box: bento/debian-8.6

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,5 +1,4 @@
 ---
-
 driver:
   name: vagrant
 
@@ -10,30 +9,18 @@ platforms:
 - name: ubuntu-16-04
   driver_config:
     box: bento/ubuntu-16.04
+- name: ubuntu-18-04
+  driver_config:
+    box: bento/ubuntu-18.04
 - name: centos-6
-  driver_config:
-    box: bento/centos-6.9
 - name: centos-7
-  driver_config:
-    box: bento/centos-7.4
 - name: oracle-6
-  driver_config:
-    box: bento/oracle-6.9
 - name: oracle-7
-  driver_config:
-    box: bento/oracle-7.3
 - name: debian-8
-  driver_config:
-    box: bento/debian-8.6
+- name: debian-9
 - name: fedora-26
-  driver_config:
-    box: bento/fedora-26
 - name: fedora-27
-  driver_config:
-    box: bento/fedora-27
 - name: opensuse-leap-42
-  driver_config:
-    box: bento/opensuse-leap-42.1
 - name: amazonlinux-1
   driver_config:
     box: realreadme/amazon2016.09

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,8 @@ matrix:
   allow_failures: # temporaray disable failing tests until all problems are fixed
     - env: INSTANCE=ubuntu-16-04 KITCHEN_LOCAL_YAML=.kitchen.dokken.yml
     - env: INSTANCE=ubuntu-16-04 CHEF_VERSION=12.14.60 KITCHEN_LOCAL_YAML=.kitchen.dokken.yml
+    - env: INSTANCE=ubuntu-18-04 KITCHEN_LOCAL_YAML=.kitchen.do.yml
+    - env: INSTANCE=ubuntu-18-04 KITCHEN_LOCAL_YAML=.kitchen.dokken.yml
     - env: INSTANCE=centos-7 KITCHEN_LOCAL_YAML=.kitchen.dokken.yml
     - env: INSTANCE=centos-7 CHEF_VERSION=12.14.60 KITCHEN_LOCAL_YAML=.kitchen.dokken.yml
     - env: INSTANCE=opensuse-42 KITCHEN_LOCAL_YAML=.kitchen.dokken.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,12 @@ env:
  - INSTANCE=ubuntu-14-04 KITCHEN_LOCAL_YAML=.kitchen.do.yml
  - INSTANCE=ubuntu-16-04 KITCHEN_LOCAL_YAML=.kitchen.do.yml
  - INSTANCE=ubuntu-16-04 CHEF_VERSION=12.14.60 KITCHEN_LOCAL_YAML=.kitchen.do.yml
+ - INSTANCE=ubuntu-18-04 KITCHEN_LOCAL_YAML=.kitchen.do.yml
  - INSTANCE=centos-6 KITCHEN_LOCAL_YAML=.kitchen.do.yml
  - INSTANCE=centos-7 KITCHEN_LOCAL_YAML=.kitchen.do.yml
  - INSTANCE=centos-7 CHEF_VERSION=12.14.60 KITCHEN_LOCAL_YAML=.kitchen.do.yml
  - INSTANCE=debian-8 KITCHEN_LOCAL_YAML=.kitchen.do.yml
+ - INSTANCE=debian-9 KITCHEN_LOCAL_YAML=.kitchen.do.yml
  - INSTANCE=fedora-26 KITCHEN_LOCAL_YAML=.kitchen.do.yml
  - INSTANCE=fedora-27 KITCHEN_LOCAL_YAML=.kitchen.do.yml
  - INSTANCE=ubuntu-14-04 KITCHEN_LOCAL_YAML=.kitchen.dokken.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,7 @@ matrix:
     - env: INSTANCE=centos-7 KITCHEN_LOCAL_YAML=.kitchen.dokken.yml
     - env: INSTANCE=centos-7 CHEF_VERSION=12.14.60 KITCHEN_LOCAL_YAML=.kitchen.dokken.yml
     - env: INSTANCE=opensuse-42 KITCHEN_LOCAL_YAML=.kitchen.dokken.yml
+    - env: INSTANCE=amazonlinux-2 KITCHEN_LOCAL_YAML=.kitchen.dokken.yml # https://github.com/inspec/train/pull/312
   include:
     - env: UNIT_AND_LINT=1
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,6 @@ env:
  - INSTANCE=centos-7 CHEF_VERSION=12.14.60 KITCHEN_LOCAL_YAML=.kitchen.dokken.yml
  - INSTANCE=oracle-6 KITCHEN_LOCAL_YAML=.kitchen.dokken.yml
  - INSTANCE=oracle-7 KITCHEN_LOCAL_YAML=.kitchen.dokken.yml
- - INSTANCE=debian-7 KITCHEN_LOCAL_YAML=.kitchen.dokken.yml
  - INSTANCE=debian-8 KITCHEN_LOCAL_YAML=.kitchen.dokken.yml
  - INSTANCE=fedora-26 KITCHEN_LOCAL_YAML=.kitchen.dokken.yml
  - INSTANCE=fedora-27 KITCHEN_LOCAL_YAML=.kitchen.dokken.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,12 +20,12 @@ env:
  - INSTANCE=centos-6 KITCHEN_LOCAL_YAML=.kitchen.do.yml
  - INSTANCE=centos-7 KITCHEN_LOCAL_YAML=.kitchen.do.yml
  - INSTANCE=centos-7 CHEF_VERSION=12.14.60 KITCHEN_LOCAL_YAML=.kitchen.do.yml
- - INSTANCE=debian-7 KITCHEN_LOCAL_YAML=.kitchen.do.yml
  - INSTANCE=debian-8 KITCHEN_LOCAL_YAML=.kitchen.do.yml
  - INSTANCE=fedora-26 KITCHEN_LOCAL_YAML=.kitchen.do.yml
  - INSTANCE=fedora-27 KITCHEN_LOCAL_YAML=.kitchen.do.yml
  - INSTANCE=ubuntu-14-04 KITCHEN_LOCAL_YAML=.kitchen.dokken.yml
  - INSTANCE=ubuntu-16-04 KITCHEN_LOCAL_YAML=.kitchen.dokken.yml
+ - INSTANCE=ubuntu-18-04 KITCHEN_LOCAL_YAML=.kitchen.dokken.yml
  - INSTANCE=ubuntu-16-04 CHEF_VERSION=12.14.60 KITCHEN_LOCAL_YAML=.kitchen.dokken.yml
  - INSTANCE=centos-6 KITCHEN_LOCAL_YAML=.kitchen.dokken.yml
  - INSTANCE=centos-7 KITCHEN_LOCAL_YAML=.kitchen.dokken.yml
@@ -33,6 +33,7 @@ env:
  - INSTANCE=oracle-6 KITCHEN_LOCAL_YAML=.kitchen.dokken.yml
  - INSTANCE=oracle-7 KITCHEN_LOCAL_YAML=.kitchen.dokken.yml
  - INSTANCE=debian-8 KITCHEN_LOCAL_YAML=.kitchen.dokken.yml
+ - INSTANCE=debian-9 KITCHEN_LOCAL_YAML=.kitchen.dokken.yml
  - INSTANCE=fedora-26 KITCHEN_LOCAL_YAML=.kitchen.dokken.yml
  - INSTANCE=fedora-27 KITCHEN_LOCAL_YAML=.kitchen.dokken.yml
  - INSTANCE=opensuse-42 KITCHEN_LOCAL_YAML=.kitchen.dokken.yml

--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ group :integration do
   gem 'kitchen-dokken'
   gem 'kitchen-inspec', '>= 0.23.1'
   gem 'kitchen-vagrant'
-  gem 'test-kitchen', '~> 1.0'
+  gem 'test-kitchen', '~> 1.20'
 end
 
 group :tools do


### PR DESCRIPTION
Simplify the configs by using dokken images and bento slugs. Make sure to fail on deprecation warnings to keep the cookbook ready for upcoming chef releases. Also add testing of Debian 9 / Ubuntu 18.04 and remove EOL Debian 7