### PR TITLE
allow setting uid/gid max by attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,14 @@ It will not:
 * `['os-hardening']['auth']['pw_warn_age'] = 7`
   number of days before maximum password age occurs to warn of impending
   change
+* `['os-hardening']['auth']['uid_min'] = 1000`
+  lower bound of UIDs assigned by useradd
+* `['os-hardening']['auth']['uid_max'] = 60000`
+  upper bound of UIDs assigned by useradd
+* `['os-hardening']['auth']['gid_min'] = 1000`
+  lower bound of GIDs assigned by groupadd
+* `['os-hardening']['auth']['gid_max'] = 60000`
+  upper bound of GIDs assigned by groupadd
 * `['os-hardening']['auth']['retries'] = 5`
   the maximum number of authentication attempts, before the account is locked for some time
 * `['os-hardening']['auth']['lockout_time'] = 600`

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -86,7 +86,9 @@ default['os-hardening']['auth']['pam']['passwdqc']['template_cookbook']      = '
 default['os-hardening']['auth']['pam']['system-auth']['template_cookbook']   = 'os-hardening'
 default['os-hardening']['auth']['root_ttys']                          = %w[console tty1 tty2 tty3 tty4 tty5 tty6]
 default['os-hardening']['auth']['uid_min']                             = 1000
+default['os-hardening']['auth']['uid_max']                             = 60000
 default['os-hardening']['auth']['gid_min']                             = 1000
+default['os-hardening']['auth']['gid_max']                             = 60000
 default['os-hardening']['auth']['sys_uid_max']                         = 999
 default['os-hardening']['auth']['sys_gid_max']                         = 999
 

--- a/recipes/login_defs.rb
+++ b/recipes/login_defs.rb
@@ -35,7 +35,9 @@ template '/etc/login.defs' do
     chfn_restrict: '', # "rwh"
     allow_login_without_home: node['os-hardening']['auth']['allow_homeless'],
     uid_min: node['os-hardening']['auth']['uid_min'],
+    uid_max: node['os-hardening']['auth']['uid_max'],
     gid_min: node['os-hardening']['auth']['gid_min'],
+    gid_max: node['os-hardening']['auth']['gid_max'],
     sys_uid_min: node['os-hardening']['auth']['sys_uid_min'],
     sys_uid_max: node['os-hardening']['auth']['sys_uid_max'],
     sys_gid_min: node['os-hardening']['auth']['sys_gid_min'],

--- a/spec/recipes/login_defs_spec.rb
+++ b/spec/recipes/login_defs_spec.rb
@@ -20,7 +20,9 @@ describe 'os-hardening::login_defs' do
   cached(:chef_run) do
     ChefSpec::ServerRunner.new do |node|
       node.normal['os-hardening']['auth']['uid_min'] = 5000
+      node.normal['os-hardening']['auth']['uid_max'] = 6000
       node.normal['os-hardening']['auth']['gid_min'] = 5000
+      node.normal['os-hardening']['auth']['gid_max'] = 6000
     end.converge(described_recipe)
   end
 
@@ -43,7 +45,9 @@ describe 'os-hardening::login_defs' do
         chfn_restrict: '',
         allow_login_without_home: false,
         uid_min: 5000,
+        uid_max: 6000,
         gid_min: 5000,
+        gid_max: 6000,
         sys_uid_min: 100,
         sys_uid_max: 999,
         sys_gid_min: 100,
@@ -57,6 +61,8 @@ describe 'os-hardening::login_defs' do
     is_expected.to render_file('/etc/login.defs').
       with_content(/^PASS_WARN_AGE\s+7$/).
       with_content(/^UID_MIN\s+5000$/).
-      with_content(/^GID_MIN\s+5000$/)
+      with_content(/^UID_MAX\s+6000$/).
+      with_content(/^GID_MIN\s+5000$/).
+      with_content(/^GID_MAX\s+6000$/)
   end
 end

--- a/templates/default/login.defs.erb
+++ b/templates/default/login.defs.erb
@@ -4,23 +4,23 @@
 #---
 
 # Configuration control definitions for the login package.
-# 
+#
 # Three items must be defined:  `MAIL_DIR`, `ENV_SUPATH`, and `ENV_PATH`. If unspecified, some arbitrary (and possibly incorrect) value will be assumed.  All other items are optional - if not specified then the described action or option will be inhibited.
-# 
+#
 # Comment lines (lines beginning with `#`) and blank lines are ignored.
 #
 #-- Modified for Linux.  --marekm
 
 # *REQUIRED for useradd/userdel/usermod*
-# 
+#
 # Directory where mailboxes reside, _or_ name of file, relative to the home directory.  If you _do_ define `MAIL_DIR` and `MAIL_FILE`, `MAIL_DIR` takes precedence.
 # Essentially:
-# 
+#
 # * `MAIL_DIR` defines the location of users mail spool files (for mbox use) by appending the username to `MAIL_DIR` as defined below.
 # * `MAIL_FILE` defines the location of the users mail spool files as the fully-qualified filename obtained by prepending the user home directory before `$MAIL_FILE`
 #
 # *NOTE*: This is no more used for setting up users MAIL environment variable which is, starting from shadow 4.0.12-1 in Debian, entirely the job of the pam_mail PAM modules.
-# 
+#
 # See default PAM configuration files provided for login, su, etc.
 # This is a temporary situation: setting these variables will soon move to `/etc/default/useradd` and the variables will then be no more supported
 MAIL_DIR        <%= @mail_dir %>
@@ -30,7 +30,7 @@ MAIL_DIR        <%= @mail_dir %>
 FAILLOG_ENAB		yes
 
 # Enable display of unknown usernames when login failures are recorded.
-# 
+#
 # *WARNING*: Unknown usernames may become world readable. See #290803 and #298773 for details about how this could become a security concern
 LOG_UNKFAIL_ENAB	no
 
@@ -110,7 +110,7 @@ PASS_WARN_AGE	<%= @password_warn_age.to_s %>
 
 # Min/max values for automatic uid selection in useradd
 UID_MIN			 <%= @uid_min.to_s %>
-UID_MAX			60000
+UID_MAX			 <%= @uid_max.to_s %>
 <% unless node['platform_family'] == 'rhel' and node['platform_version'].to_f < 6.0 %>
 # System accounts
 SYS_UID_MIN		  <%= @sys_uid_min.to_s %>
@@ -119,7 +119,7 @@ SYS_UID_MAX		  <%= @sys_uid_max.to_s %>
 
 # Min/max values for automatic gid selection in groupadd
 GID_MIN			 <%= @gid_min.to_s %>
-GID_MAX			60000
+GID_MAX			 <%= @gid_max.to_s %>
 <% unless node['platform_family'] == 'rhel' and node['platform_version'].to_f < 6.0 %>
 # System accounts
 SYS_GID_MIN		  <%= @sys_gid_min.to_s %>
@@ -216,4 +216,3 @@ ENCRYPT_METHOD SHA512
 # This variable is deprecated. You should use ENCRYPT_METHOD.
 #
 #MD5_CRYPT_ENAB no
-


### PR DESCRIPTION
This change un-hardcodes the maximum user and group IDs assigned by useradd and groupadd respectively. Having them hardcoded can present problems for nodes that are configured with directory services (e.g. LDAP) and the range conflicts with IDs from there. These attributes will allow users to configure a non-conflicting ID range.

Signed-off-by: Matt Kulka <mkulka@parchment.com>