### PR TITLE
Fix Fedora EOL

### DIFF
--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -52,13 +52,13 @@ platforms:
     intermediate_instructions:
     - RUN /usr/bin/apt-get update
     pid_one_command: /bin/systemd
-- name: fedora-26
+- name: fedora-27
   driver:
     image: dokken/fedora-27
     pid_one_command: /usr/lib/systemd/systemd
     intermediate_instructions:
     - RUN dnf install -y yum
-- name: fedora-27
+- name: fedora-28
   driver:
     image: dokken/fedora-28
     pid_one_command: /usr/lib/systemd/systemd


### PR DESCRIPTION
Missing renaming of platform for dokken

Signed-off-by: Artem Sidorenko <artem@posteo.de>