### PR TITLE
Remove sysctl cookbook dependency and use new native sysctl resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,7 @@ It will not:
 
 ## Requirements
 
-* Chef >= 14
-* Cookbooks:
-  * Sander van Zoest sysctl `https://github.com/svanzoest-cookbooks/sysctl`
+* Chef >= 14.0
 
 ### Platform
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -38,8 +38,6 @@ supports 'fedora', '>= 26.0'
 supports 'suse'
 supports 'opensuseleap', '>= 42.1'
 
-depends 'sysctl', '~> 1.0'
-
 recipe 'os-hardening::default', 'harden the operating system (all recipes)'
 recipe 'os-hardening::limits', 'prevent core dumps'
 recipe 'os-hardening::login_defs', 'harden /etc/login.defs'

--- a/recipes/sysctl.rb
+++ b/recipes/sysctl.rb
@@ -130,7 +130,7 @@ node.default['sysctl']['params']['fs']['suid_dumpable'] =
 if node.attribute?('sysctl') && node['sysctl'].attribute?('params')
   coerce_attributes(node['sysctl']['params']).each do |x|
     k, v = x.split('=')
-    sysctl_param k do
+    sysctl k do
       value v
     end
   end

--- a/spec/recipes/sysctl_spec.rb
+++ b/spec/recipes/sysctl_spec.rb
@@ -158,7 +158,7 @@ describe 'os-hardening::sysctl' do
         let(:network_forwarding) { true }
 
         it 'should enable IPv4 forwarding in sysctl attributes' do
-          expect(chef_run).to apply_sysctl_param('net.ipv4.ip_forward').with(
+          expect(chef_run).to apply_sysctl('net.ipv4.ip_forward').with(
             value: '1'
           )
         end
@@ -168,7 +168,7 @@ describe 'os-hardening::sysctl' do
         let(:network_forwarding) { false }
 
         it 'should disable IPv4 forwarding in sysctl attributes' do
-          expect(chef_run).to apply_sysctl_param('net.ipv4.ip_forward').with(
+          expect(chef_run).to apply_sysctl('net.ipv4.ip_forward').with(
             value: '0'
           )
         end
@@ -178,7 +178,7 @@ describe 'os-hardening::sysctl' do
     describe 'IPv6 forwarding' do
       RSpec.shared_examples 'IPv6 forwarding in sysctl attributes' do |state|
         it "should #{state == 1 ? 'enable' : 'disable'} IPv6 forwarding in sysctl attributes" do # rubocop:disable Metrics/LineLength
-          expect(chef_run).to apply_sysctl_param('net.ipv6.conf.all.forwarding').with(
+          expect(chef_run).to apply_sysctl('net.ipv6.conf.all.forwarding').with(
             value: state.to_s
           )
         end
@@ -221,7 +221,7 @@ describe 'os-hardening::sysctl' do
         let(:ipv6_enable) { true }
 
         it 'should not disable IPv6' do
-          expect(chef_run).to apply_sysctl_param('net.ipv4.ip_forward').with(
+          expect(chef_run).to apply_sysctl('net.ipv4.ip_forward').with(
             value: '0'
           )
         end
@@ -231,7 +231,7 @@ describe 'os-hardening::sysctl' do
         let(:ipv6_enable) { false }
 
         it 'should not disable IPv6' do
-          expect(chef_run).to apply_sysctl_param('net.ipv6.conf.all.forwarding').with(
+          expect(chef_run).to apply_sysctl('net.ipv6.conf.all.forwarding').with(
             value: '0'
           )
         end
@@ -242,7 +242,7 @@ describe 'os-hardening::sysctl' do
       RSpec.shared_examples 'ARP restrictions in sysctl attributes' do |arp_ignore, arp_announce| # rubocop:disable Metrics/LineLength
         describe 'arp_ignore' do
           it "should be set to #{arp_ignore}" do
-            expect(chef_run).to apply_sysctl_param('net.ipv4.conf.all.arp_ignore').with(
+            expect(chef_run).to apply_sysctl('net.ipv4.conf.all.arp_ignore').with(
               value: arp_ignore.to_s
             )
           end
@@ -250,7 +250,7 @@ describe 'os-hardening::sysctl' do
 
         describe 'arp_announce' do
           it "should be set to #{arp_announce}" do
-            expect(chef_run).to apply_sysctl_param('net.ipv4.conf.all.arp_announce').with(
+            expect(chef_run).to apply_sysctl('net.ipv4.conf.all.arp_announce').with(
               value: arp_announce.to_s
             )
           end
@@ -275,7 +275,7 @@ describe 'os-hardening::sysctl' do
         let(:enable_module_loading) { true }
 
         it 'should not set the sysctl flag' do
-          expect(chef_run).to_not apply_sysctl_param('kernel.modules_disabled')
+          expect(chef_run).to_not apply_sysctl('kernel.modules_disabled')
         end
 
         describe 'rebuild of initramfs' do
@@ -295,7 +295,7 @@ describe 'os-hardening::sysctl' do
         let(:enable_module_loading) { false }
 
         it 'should disable module loading via sysctl flag' do
-          expect(chef_run).to apply_sysctl_param('kernel.modules_disabled').with(
+          expect(chef_run).to apply_sysctl('kernel.modules_disabled').with(
             value: '1'
           )
         end
@@ -319,7 +319,7 @@ describe 'os-hardening::sysctl' do
         let(:enable_sysrq) { true }
 
         it 'should enable sysrq with safe value' do
-          expect(chef_run).to apply_sysctl_param('kernel.sysrq').with(
+          expect(chef_run).to apply_sysctl('kernel.sysrq').with(
             value: '244'
           )
         end
@@ -329,7 +329,7 @@ describe 'os-hardening::sysctl' do
         let(:enable_sysrq) { false }
 
         it 'should disable sysrq' do
-          expect(chef_run).to apply_sysctl_param('kernel.sysrq').with(
+          expect(chef_run).to apply_sysctl('kernel.sysrq').with(
             value: '0'
           )
         end
@@ -341,7 +341,7 @@ describe 'os-hardening::sysctl' do
         let(:enable_core_dump) { true }
 
         it 'should set suid_dumpable to safe value' do
-          expect(chef_run).to apply_sysctl_param('fs.suid_dumpable').with(
+          expect(chef_run).to apply_sysctl('fs.suid_dumpable').with(
             value: '2'
           )
         end
@@ -351,7 +351,7 @@ describe 'os-hardening::sysctl' do
         let(:enable_core_dump) { false }
 
         it 'should set suid_dumpable to default value' do
-          expect(chef_run).to apply_sysctl_param('fs.suid_dumpable').with(
+          expect(chef_run).to apply_sysctl('fs.suid_dumpable').with(
             value: '0'
           )
         end


### PR DESCRIPTION
Sysctl cookbook is deprecated and resource has been integrated to Chef as of 14.0.