### PR TITLE
Use full path for executing pam-auth-update

### DIFF
--- a/recipes/pam.rb
+++ b/recipes/pam.rb
@@ -92,7 +92,7 @@ when 'debian'
   end
 
   execute 'update-pam' do
-    command 'pam-auth-update --package'
+    command '/usr/sbin/pam-auth-update --package'
   end
 
   # do config for rhel-family


### PR DESCRIPTION
On Debian-based distros, pam-auth-update is located at /usr/sbin/pam-auth-update. However, when running chef-client as a cron job, /usr/sbin may not be available on the path, resulting in an error. This affects nodes using the Azure Chef extension, among others.

Fixes #237