### PR TITLE
Removal of fedora 27 as its EOL

### DIFF
--- a/.kitchen.do.yml
+++ b/.kitchen.do.yml
@@ -26,9 +26,9 @@ platforms:
 - name: debian-9
   driver_config:
     image: debian-9-x64
-- name: fedora-27
-  driver_config:
-    image: fedora-27-x64
 - name: fedora-28
   driver_config:
     image: fedora-28-x64
+- name: fedora-29
+  driver_config:
+    image: fedora-29-x64

--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -46,15 +46,15 @@ platforms:
     intermediate_instructions:
     - RUN /usr/bin/apt-get update
     pid_one_command: /bin/systemd
-- name: fedora-27
-  driver:
-    image: dokken/fedora-27
-    pid_one_command: /usr/lib/systemd/systemd
-    intermediate_instructions:
-    - RUN dnf install -y yum
 - name: fedora-28
   driver:
     image: dokken/fedora-28
+    pid_one_command: /usr/lib/systemd/systemd
+    intermediate_instructions:
+    - RUN dnf install -y yum
+- name: fedora-29
+  driver:
+    image: dokken/fedora-29
     pid_one_command: /usr/lib/systemd/systemd
     intermediate_instructions:
     - RUN dnf install -y yum

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -14,8 +14,8 @@ platforms:
 - name: oracle-6
 - name: oracle-7
 - name: debian-9
-- name: fedora-27
 - name: fedora-28
+- name: fedora-29
 - name: opensuse-leap-42
 - name: amazonlinux-1
   driver_config:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ env:
  - INSTANCE=centos-7 KITCHEN_LOCAL_YAML=.kitchen.do.yml
  - INSTANCE=centos-7 CHEF_VERSION=14.0.190 KITCHEN_LOCAL_YAML=.kitchen.do.yml
  - INSTANCE=debian-9 KITCHEN_LOCAL_YAML=.kitchen.do.yml
- - INSTANCE=fedora-27 KITCHEN_LOCAL_YAML=.kitchen.do.yml
  - INSTANCE=fedora-28 KITCHEN_LOCAL_YAML=.kitchen.do.yml
+ - INSTANCE=fedora-29 KITCHEN_LOCAL_YAML=.kitchen.do.yml
  - INSTANCE=ubuntu-16-04 KITCHEN_LOCAL_YAML=.kitchen.dokken.yml
  - INSTANCE=ubuntu-18-04 KITCHEN_LOCAL_YAML=.kitchen.dokken.yml
  - INSTANCE=ubuntu-16-04 CHEF_VERSION=14.0.190 KITCHEN_LOCAL_YAML=.kitchen.dokken.yml
@@ -29,8 +29,8 @@ env:
  - INSTANCE=oracle-6 KITCHEN_LOCAL_YAML=.kitchen.dokken.yml
  - INSTANCE=oracle-7 KITCHEN_LOCAL_YAML=.kitchen.dokken.yml
  - INSTANCE=debian-9 KITCHEN_LOCAL_YAML=.kitchen.dokken.yml
- - INSTANCE=fedora-27 KITCHEN_LOCAL_YAML=.kitchen.dokken.yml
  - INSTANCE=fedora-28 KITCHEN_LOCAL_YAML=.kitchen.dokken.yml
+ - INSTANCE=fedora-29 KITCHEN_LOCAL_YAML=.kitchen.dokken.yml
  - INSTANCE=opensuse-42 KITCHEN_LOCAL_YAML=.kitchen.dokken.yml
  - INSTANCE=amazonlinux-1 KITCHEN_LOCAL_YAML=.kitchen.dokken.yml
  - INSTANCE=amazonlinux-2 KITCHEN_LOCAL_YAML=.kitchen.dokken.yml


### PR DESCRIPTION
and switching Fedora 29 as current latest release

Signed-off-by: Artem Sidorenko <artem@posteo.de>