### PR TITLE
Allow dependabot to check ruby dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This change allows dependabot to check any dependencies defined within the Gemfile of this project and submit version bumps on a weekly basis if there are more recent versions of the package in order to keep dependencies up-to-date.

https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/configuration-options-for-dependency-updates