### PR TITLE
expose pam_unix.so options to an attribute

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -100,6 +100,7 @@ default['os-hardening'].tap do |os_hardening|
       pam['passwdqc']['options'] = 'min=disabled,disabled,16,12,8'
       pam['cracklib']['options'] = 'try_first_pass retry=3 type='
       pam['pwquality']['options'] = 'try_first_pass retry=3 type='
+      pam['unix']['options'] = 'shadow nullok try_first_pass use_authtok remember=5'
       pam['tally2']['template_cookbook'] = 'os-hardening'
       pam['passwdqc']['template_cookbook'] = 'os-hardening'
       pam['system-auth']['template_cookbook'] = 'os-hardening'

--- a/templates/default/rhel_system_auth.erb
+++ b/templates/default/rhel_system_auth.erb
@@ -31,7 +31,7 @@ password    requisite     pam_cracklib.so <%= node['os-hardening']['auth']['pam'
 
 # NSA 2.3.3.5 Upgrade Password Hashing Algorithm to SHA-512
 # NSA 2.3.3.6 Limit Password Reuse
-password    sufficient    pam_unix.so sha512 shadow nullok try_first_pass use_authtok remember=5
+password    sufficient    pam_unix.so sha512 <%= node['os-hardening']['auth']['pam']['unix']['options'] %>
 password    required      pam_deny.so
 
 session     optional      pam_keyinit.so revoke


### PR DESCRIPTION
allow changing pam_unix.so options excluding sha512

I have a requirement to be able to set `remember=7` which currently cant be changed.