### PR TITLE
Remove vfat as a disabled filesystem

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -124,7 +124,7 @@ default['os-hardening'].tap do |os_hardening|
     # may contain: change_user
     security['users']['allow'] = []
     security['kernel']['enable_module_loading'] = true
-    security['kernel']['disable_filesystems'] = %w[cramfs freevxfs jffs2 hfs hfsplus squashfs udf vfat]
+    security['kernel']['disable_filesystems'] = %w[cramfs freevxfs jffs2 hfs hfsplus squashfs udf]
     security['kernel']['enable_sysrq'] = false
     security['kernel']['enable_core_dump'] = false
     security['suid_sgid']['enforce'] = true


### PR DESCRIPTION
On systems with secure boot, `/boot/efi` is `vfat`, and disabling it causes the host to no longer boot cleanly. Depending on the environment, it may not boot at all. At this time, secure boot seems common enough that I think the default should be to not disable `vfat` filesystems, because it is likely to cause issues for an unsuspecting user.