### PR TITLE
CI: disable debian-9 dokken tests for now

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
           - centos-7
           - centos-8
           - oracle-7
-          - debian-9
+#          - debian-9 # something is broken here
           - debian-10
           - fedora-28
           - fedora-29


### PR DESCRIPTION
something is broken here