### PR TITLE
CI: run for all PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,8 +9,6 @@ on:
     branches:
       - '*'
   pull_request:
-    types:
-      - opened
     branches:
       - master
 


### PR DESCRIPTION
most likely the dokken tests are blocked because of this limitation