### PR TITLE
Fix: debian-13 and ubuntu-26.04 compatbility

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,6 +90,7 @@ jobs:
         kitchen_distro:
           - default-ubuntu-22-04
           - default-ubuntu-24-04
+          - default-ubuntu-26-04
 
           - default-centos-stream-9
           - default-centos-stream-10
@@ -101,6 +102,8 @@ jobs:
           - default-rockylinux-8
           - default-rockylinux-9
           - default-rockylinux-10
+
+          - default-debian-13
 
           - default-fedora-43
           - default-fedora-44

--- a/README.md
+++ b/README.md
@@ -30,11 +30,12 @@ It will not:
 
 ### Platform
 
-- Ubuntu 20.04, 22.04, 24.04
+- Ubuntu 20.04, 22.04, 24.04, 26.04
 - CentOS Stream 9, 10
 - AlmaLinux 8, 9, 10
 - Rocky Linux 8, 9, 10
 - Oracle Linux 8, 9, 10
+- Debian 13
 - Fedora 43, 44
 
 ## Attributes

--- a/recipes/sysctl.rb
+++ b/recipes/sysctl.rb
@@ -22,21 +22,16 @@
 
 ::Chef::Recipe.send(:include, SysctlCookbook::SysctlHelpers::Param)
 
-# cleanup of old sysctl related configurations. This can be removed at some point in the future
-# https://github.com/dev-sec/chef-os-hardening/issues/166#issuecomment-322433264
-# https://github.com/sous-chefs/sysctl/pull/61/files#diff-25e5d4a4446ae12a0d6f1162b6160375
-old_sysctl_conf_file = '/etc/sysctl.conf'
-if platform_family?('arch', 'debian', 'rhel', 'fedora', 'amazon', 'suse')
-  old_sysctl_conf_file = if platform_family?('suse') && node['platform_version'].to_f < 12.0
-                           '/etc/sysctl.conf'
-                         else
-                           '/etc/sysctl.d/99-chef-attributes.conf'
-                         end
-end
-
-file 'cleanup of old sysctl settings' do
-  path old_sysctl_conf_file
-  action :delete
+# on debian and ubuntu 26.04 there is an upstream issue with sysctl
+# https://github.com/chef/chef/issues/15263
+if (platform?('debian') && node['platform_version'].to_f >= 13) ||
+   (platform?('ubuntu') && node['platform_version'].to_f >= 26.04)
+  file '/etc/sysctl.conf' do
+    content <<~EOF
+      # this is a placeholder due to chef upstream bug https://github.com/chef/chef/issues/15263
+      # this placeholder was created by os-hardening cookbook as a workaround
+    EOF
+  end
 end
 
 # default attributes


### PR DESCRIPTION
let's use a placeholder file /etc/sysctl.conf

(and remove the old cleanup code)

Workaround for upstream https://github.com/chef/chef/issues/15263