### PR TITLE
 CI: removing support of debian 12

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,7 +57,6 @@ jobs:
           - oracle-9
           - oracle-10
 
-          - debian-12
           - debian-13
 
           - fedora-43
@@ -102,8 +101,6 @@ jobs:
           - default-rockylinux-8
           - default-rockylinux-9
           - default-rockylinux-10
-
-          - default-debian-12
 
           - default-fedora-43
           - default-fedora-44

--- a/.kitchen.do.yml
+++ b/.kitchen.do.yml
@@ -54,12 +54,6 @@ platforms:
   driver_config:
     image: rockylinux-10-x64
 
-- name: debian-12
-  driver_config:
-    image: debian-12-x64
-  lifecycle:
-    post_create:
-      - remote: sleep 10; while pgrep apt-get >/dev/null; do echo "Waiting for apt-get..."; sleep 5; done # let the installation of DO droplet-agent to finish and unlock dpkg
 - name: debian-13
   driver_config:
     image: debian-13-x64

--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -89,12 +89,6 @@ platforms:
     image: dokken/oraclelinux-10
     pid_one_command: /usr/lib/systemd/systemd
 
-- name: debian-12
-  driver:
-    image: dokken/debian-12
-    intermediate_instructions:
-    - RUN /usr/bin/apt-get update
-    pid_one_command: /bin/systemd
 - name: debian-13
   driver:
     image: dokken/debian-13

--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ It will not:
 - AlmaLinux 8, 9, 10
 - Rocky Linux 8, 9, 10
 - Oracle Linux 8, 9, 10
-- Debian 12
 - Fedora 43, 44
 
 ## Attributes


### PR DESCRIPTION
it's EOL and we can't test it on DO anymore