### PR TITLE
CI: use bigger DO flavor

### DIFF
--- a/.kitchen.do.yml
+++ b/.kitchen.do.yml
@@ -1,6 +1,6 @@
 driver:
   name: digitalocean
-  size: s-1vcpu-1gb
+  size: s-1vcpu-2gb
   region: nyc3
 
 transport:


### PR DESCRIPTION
as 1GB is too small for the most current distros